### PR TITLE
Hcn 131 add devise devise token auth

### DIFF
--- a/app/controllers/api/overrides/registrations_controller.rb
+++ b/app/controllers/api/overrides/registrations_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module Overrides
+    class RegistrationsController < DeviseTokenAuth::RegistrationsController
+      before_action :configure_permitted_parameters
+    
+      protected
+    
+      def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up, keys: %i( name 
+    																													phone_number
+    																													post_code
+    																													address
+    																												  default_confirm_success_url)
+    		)
+      end
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,11 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # email認証リファレンス https://devise-token-auth.gitbook.io/devise-token-auth/config/email_auth
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => 'smtp', :port => 1025 }
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
+  config.navigational_formats = [':json']
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -51,7 +51,7 @@ DeviseTokenAuth.setup do |config|
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can
   # do so by enabling this flag. NOTE: This feature is highly experimental!
-  # config.enable_standard_devise_support = false
+  config.enable_standard_devise_support = true
 
   # By default DeviseTokenAuth will not send confirmation email, even when including
   # devise confirmable module. If you want to use devise confirmable module and

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,7 +5,7 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
@@ -56,5 +56,5 @@ DeviseTokenAuth.setup do |config|
   # By default DeviseTokenAuth will not send confirmation email, even when including
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
-  # config.send_confirmation_email = true
+  config.send_confirmation_email = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks]
+  mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks], controllers: {
+    registrations: 'api/overrides/registrations'
+  }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,8 @@ services:
     stdin_open: true
     depends_on:
       - db
+  smtp:
+    image: schickling/mailcatcher
+    ports:
+      - "1080:1080"
+      - "1025:1025"


### PR DESCRIPTION
## 例

[link](https://dev.classmethod.jp/articles/pull-request-template/)

## やったこと
* このプルリクで何をしたのか？

- API側新規登録機能実装

## やらないこと
* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
- API側のみでフロントには対応しない

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
- postmanからリクエストを送ると、メールが届きlocalhost8000へ遷移する

## できなくなること（ユーザ目線）
なし
* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認
```ruby
手順
1.postmanでリクエスト
2.メール確認
3.メールのリンククリック
4.ページへリダイレクトするのを確認
```
* どのような動作確認を行ったのか？　結果はどうか？
- postmanで下記のパラメータをセットしてリクエスト
メソッド: POST  
エンドポイント: http://localhost:3000/api/users/
```ruby
name: 任意
email: 任意
password: password
password_confirmation: password
post_code: 任意
address: 任意
phone_number: 任意
confirm_success_url: localhost:8000
```
[![Image from Gyazo](https://i.gyazo.com/2853a08dc5180f33f8a12e7c59a2d139.png)](https://gyazo.com/2853a08dc5180f33f8a12e7c59a2d139)
- http://localhost:1080/ へアクセス
[![Image from Gyazo](https://i.gyazo.com/75c44b922ac634a97c0f3b26b86c246d.png)](https://gyazo.com/75c44b922ac634a97c0f3b26b86c246d)
- メールのリンククリックすると画面へ遷移する
[![Image from Gyazo](https://i.gyazo.com/26355db4c522b9a78e9e72df900bc662.png)](https://gyazo.com/26355db4c522b9a78e9e72df900bc662)
## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
