### PR TITLE
build: create office model

### DIFF
--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,0 +1,2 @@
+class Office < ApplicationRecord
+end

--- a/db/migrate/20220509061906_create_offices.rb
+++ b/db/migrate/20220509061906_create_offices.rb
@@ -1,0 +1,18 @@
+class CreateOffices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :offices do |t|
+      t.string :name
+      t.string :title
+      t.integer :holiday
+      t.string :business_day_detail
+      t.string :address
+      t.integer :post_code
+      t.integer :phone_number
+      t.integer :fax_number
+      t.integer :user_id
+      t.integer :specialist_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_09_013022) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_09_061906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "offices", force: :cascade do |t|
+    t.string "name"
+    t.string "title"
+    t.integer "holiday"
+    t.string "business_day_detail"
+    t.string "address"
+    t.integer "post_code"
+    t.integer "phone_number"
+    t.integer "fax_number"
+    t.integer "user_id"
+    t.integer "specialist_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false

--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :office do
+    name { "MyString" }
+    title { "MyString" }
+    holiday { 1 }
+    business_day_detail { "MyString" }
+    address { "MyString" }
+    post_code { 1 }
+    phone_number { 1 }
+    fax_number { 1 }
+    user_id { 1 }
+    specialist_id { 1 }
+  end
+end

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Office, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## やったこと

* Officeモデルの作成・カラム追加

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* railsコンソール内でテーブルとカラムの確認
```
> ActiveRecord::Base.connection.tables
=> ["schema_migrations", "ar_internal_metadata", "users", "offices"]
> Office.column_names
=> 
["id",                                                            
 "name",                                                          
 "title",                                                         
 "holiday",                                                       
 "business_day_detail",                                           
 "address",                                                       
 "post_code",                                                     
 "phone_number",                                                  
 "fax_number",                                                    
 "user_id",                                                       
 "specialist_id",                                                 
 "created_at",                                                    
 "updated_at"] 
```
