### PR TITLE
ケアマネ新規登録

### DIFF
--- a/app/controllers/api/overrides/specialist_registrations_controller.rb
+++ b/app/controllers/api/overrides/specialist_registrations_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module Overrides
+    class SpecialistRegistrationsController < DeviseTokenAuth::RegistrationsController
+      before_action :configure_permitted_parameters
+    
+      protected
+    
+      def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up, keys: %i( name 
+    																													phone_number
+    																													post_code
+    																													address
+    																												  default_confirm_success_url).merge
+    		)
+      end
+    end
+  end
+end

--- a/app/controllers/api/overrides/specialist_registrations_controller.rb
+++ b/app/controllers/api/overrides/specialist_registrations_controller.rb
@@ -3,6 +3,11 @@ module Api
     class SpecialistRegistrationsController < DeviseTokenAuth::RegistrationsController
       before_action :configure_permitted_parameters
     
+      def create
+        super do |resource|
+          user_type_specialist = puts resource.specialist!
+        end
+      end
       protected
     
       def configure_permitted_parameters
@@ -10,7 +15,7 @@ module Api
     																													phone_number
     																													post_code
     																													address
-    																												  default_confirm_success_url).merge
+    																												  default_confirm_success_url)
     		)
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  enum user_type: { costomer: 0, specialist: 1 }
             # Include default devise modules.
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :trackable, :validatable,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks], controllers: {
     registrations: 'api/overrides/registrations'
   }
+  devise_scope :user do
+    post 'specialist/registrations', to: 'api/overrides/specialist_registrations#create'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
     registrations: 'api/overrides/registrations'
   }
   devise_scope :user do
-    post 'specialist/registrations', to: 'api/overrides/specialist_registrations#create'
+    post 'user', to: 'api/overrides/specialist_registrations#create'
   end
 end

--- a/db/migrate/20220509083245_add_user_type_to_users.rb
+++ b/db/migrate/20220509083245_add_user_type_to_users.rb
@@ -1,0 +1,5 @@
+class AddUserTypeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :user_type, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_09_013022) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_09_083245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "specialists", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_specialists_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_specialists_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_specialists_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_specialists_on_uid_and_provider", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", default: "email", null: false
@@ -34,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_09_013022) do
     t.json "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_type", default: 0, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 例

[link](https://dev.classmethod.jp/articles/pull-request-template/)

## チケットへのリンク

* https://example.com

## やったこと

・ケアマネージャー用の新規登録処理のAPI作成

## やらないこと

・rspecのテストやってません

## できるようになること（ユーザ目線）

・ケアマネージャー用の新規登録をするとuser_typeの値がデフォルトのカスタマーからスペシャリストになる

## できなくなること（ユーザ目線）

なし

## 動作確認

・ポストマンでケアマネ用のルーティングにリクエストを送る
https://gyazo.com/d795adce503c96b7b783287369e87bb8

・ユーザータイプがスペシャリストのuserが出来上がる
https://gyazo.com/d30bc5fec0cfaaf442491d56bd5b8630

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
