### PR TITLE
postmanからログイン・ログアウト処理ができる

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,24 +1,23 @@
 class User < ApplicationRecord
 
-  enum user_type: { customer: 0, specialist: 1 }
-            # Include default devise modules.
-
-  # Include default devise modules.
-
   devise :database_authenticatable, :registerable,
-          :recoverable, :rememberable, :trackable, :validatable,
-          :confirmable
+          :recoverable, :rememberable, :validatable, :confirmable
+
   include DeviseTokenAuth::Concerns::User
+
+  enum user_type: { customer: 0, specialist: 1 }
+
+  validates :name, :phone_number, :post_code, :address, :email, presence: true
+  validates :phone_number, uniqueness: true
 
   def set_user_type(type)
     set_specialist if type == :specialist
   end
 
+  private
+
   def set_specialist
     self.specialist!
   end
-
-  validates :name, :phone_number, :post_code, :address, :email, presence: true
-  validates :phone_number, uniqueness: true
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,23 +20,11 @@ Bundler.require(*Rails.groups)
 
 module Api
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    config.api_only = true
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end


### PR DESCRIPTION
## やったこと
1. `app/mode/user.rb`内、deviseの`trackable`の無効化 
```ruby
# app/models/user.rb
class User < ActiveRecord::Base
  devise :database_authenticatable, :recoverable,
         :validatable, :registerable, :omniauthable

  # 上記のdeveseオプションのtrackable削除
  :trackable

  include DeviseTokenAuth::Concerns::User
end
```
[Qiita::削除した背景](https://qiita.com/terufumi1122/items/d5530bc87689d886dee8)
[stackOverFllow::より詳しい説明や理由](https://stackoverflow.com/questions/33008187/devise-error-undefined-method-current-sign-in-ip)
2. middleware追加 セッションを維持してくれない
```ruby
# config/application.rb
module Api
  class Application < Rails::Application
    config.load_defaults 7.0
    config.i18n.default_locale = :ja
    config.time_zone = 'Tokyo'
    config.active_record.default_timezone = :local
    config.api_only = true
    # 追加
    config.middleware.use ActionDispatch::Session::CookieStore
  end
end
```
## やらないこと

画面からはできない・まだPOSTMANのみ

## できるようになること（ユーザ目線）

APIを直接叩けばログイン処理ができる

## 動作確認
- 下記手順動画
https://www.loom.com/share/f4a1eb32b51841499ad85c9c4d2710ba
1. パラメータセットしてログインする
2. 前回のheader情報をリクエストheaderにセットする(動画参照)
3. ログアウトをリクエストする

## 使用するパラメータなど
- 前提
**本登録を済ませたカスタマーが存在すること**
- セットするパラメーター (人によって変わる)
```ruby
email: foobar111@example.com
password: password
```
- ログインAPI
```ruby
http://localhost:3000/api/users/sign_in
```
- ログアウトAPI
```ruby
http://localhost:3000/api/users/sign_out
```