### PR TITLE
build: install gem FlagShifTzu 営業日フラグ制御

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'devise_token_auth', '>= 1.2.0', git: "https://github.com/lynndylanhurley/de
 
 gem 'rack-cors'
 
+gem 'flag_shih_tzu'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    flag_shih_tzu (0.3.23)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.10.0)
@@ -248,6 +249,7 @@ DEPENDENCIES
   devise (~> 4.8, >= 4.8.1)
   devise_token_auth (>= 1.2.0)!
   factory_bot_rails (~> 6.2)
+  flag_shih_tzu
   pg (~> 1.1)
   puma (~> 5.0)
   rack-cors

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,3 +1,15 @@
 class Office < ApplicationRecord
+  include FlagShihTzu
   belongs_to :user
+
+  has_flags(
+    1 => :sunday,
+    2 => :monday,
+    3 => :tuesday,
+    4 => :wednesday,
+    5 => :thursday,
+    6 => :fridayr,
+    7 => :saturday
+  )
+
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -8,7 +8,7 @@ class Office < ApplicationRecord
     3 => :tuesday,
     4 => :wednesday,
     5 => :thursday,
-    6 => :fridayr,
+    6 => :friday,
     7 => :saturday
   )
 

--- a/db/migrate/20220510060242_create_offices.rb
+++ b/db/migrate/20220510060242_create_offices.rb
@@ -4,7 +4,7 @@ class CreateOffices < ActiveRecord::Migration[7.0]
 
       t.string :name
       t.string :title
-      t.integer :flags, default: 0, null: false
+      t.integer :holiday
       t.string :business_day_detail
       t.string :address
       t.string :post_code

--- a/db/migrate/20220510060242_create_offices.rb
+++ b/db/migrate/20220510060242_create_offices.rb
@@ -4,7 +4,7 @@ class CreateOffices < ActiveRecord::Migration[7.0]
 
       t.string :name
       t.string :title
-      t.integer :holiday
+      t.integer :flags, default: 0, null: false
       t.string :business_day_detail
       t.string :address
       t.string :post_code

--- a/db/migrate/20220516091139_rename_holiday_to_flags_in_offices.rb
+++ b/db/migrate/20220516091139_rename_holiday_to_flags_in_offices.rb
@@ -1,0 +1,13 @@
+class RenameHolidayToFlagsInOffices < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :offices, :holiday, :flags
+    change_column_null :offices, :flags, false
+    change_column_default :offices, :flags, 0
+  end
+
+  def down
+    rename_column :offices, :flags, :holiday
+    change_column_null :offices, :holiday, true
+    change_column_default :offices, :holiday, nil
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,6 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
-Office.create(name: 'ホームケアナビ佐渡1', title: '事業所タイトル1', holiday: '8', business_day_detail:'営業日の説明が入ります', address:'東京都', post_code:'000-0000', phone_number:'0224568976', fax_number:'0962738765', user_id:'1', )
-Office.create(name: 'ホームケアナビ佐渡2', title: '事業所タイト2', holiday: '8', business_day_detail:'営業日の説明が入ります', address:'東京都', post_code:'000-0000', phone_number:'0224568976', fax_number:'0962738765', user_id:'2', )
-Office.create(name: 'ホームケアナビ佐渡3', title: '事業所タイトル3', holiday: '8', business_day_detail:'営業日の説明が入ります', address:'東京都', post_code:'000-0000', phone_number:'0224568976', fax_number:'0962738765', user_id:'3', )
+Office.create(name: 'ホームケアナビ佐渡1ホームケアナビ佐渡1', title: '事業所タイトル1事業所タイトル1', flags: '9', business_day_detail:'営業日の説明が入ります営業日の説明が入ります', address:'東京都中央区入船3-9-1第二細矢ビル1階', post_code:'001-0001', phone_number:'0001-01-0001', fax_number:'096-273-8765', user_id:'1', )
+Office.create(name: 'ホームケアナビ佐渡2ホームケアナビ佐渡2', title: '事業所タイトル2事業所タイトル2', flags: '8', business_day_detail:'営業日の説明が入ります営業日の説明が入ります', address:'東京都中央区新川2-27-3', post_code:'002-0002', phone_number:'0002-02-0002', fax_number:'090-145-5678', user_id:'2', )
+Office.create(name: 'ホームケアナビ佐渡3ホームケアナビ佐渡3', title: '事業所タイトル3事業所タイトル3', flags: '96', business_day_detail:'営業日の説明が入ります営業日の説明が入ります', address:'東京都中央区明石町1-6', post_code:'003-0003', phone_number:'0003-03-0003', fax_number:'050-687-2915', user_id:'3', )


### PR DESCRIPTION
## 説明

- gem flag_shih_tzu https://rubygems.org/gems/flag_shih_tzu
- 実装手順で参考にした記事　https://weseek.co.jp/tech/819/
```
この定義した数字を足し合わせていくことで、事業所がいつ休業日なのかを表す。

1  日曜日
2  月曜日
4  火曜日
8  水曜日
16  木曜日
32  金曜日
64  土曜日
```

## やったこと

* 機能フラグ(Feature Flag)を追加し営業日の各フラグを制御した

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

- dockerコンテナを消して再ビルドする
`docker-compose build`

* カラム名を変更したので、`rails:db:migrate`を実行する
```
 Status   Migration ID    Migration Name
--------------------------------------------------
   up     20220509013022  Devise token auth create users
   up     20220509083245  Add user type to users
   up     20220510060242  Create offices
   up     20220516091139  Rename holiday to flags in offices
```
* `rails:db:seed`でダミーデータを作る

* flagsの値が加算されているか確認
```
> Office.find(1)
id: 1,                                                                          
flags: 9,
（以下略）
```

## その他

* カラム名をholidayで登録しようとするとエラーが発生し、カラム名をflagsに変更したところうまくいった。
* seed.rbを修正したので、`rails:db:seed`でデータを作成できるようにしました。

* その他コマンド

```
フラグ一覧を表示する
> Office.find(1).all_flags
選択したフラグを表示する
> Office.find(1).selected_flags
```