### PR TITLE
add：specialists-mail

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,11 @@
+<% if @resource.specialist? %>
+<p>スペシャリスト</p>
+<% else @resource.customer? %>
+<p>カスタマー</p>
+<% end %>
+
+<p><%= t(:welcome).capitalize + ' ' + @email %>!</p>
+
+<p><%= t '.confirm_link_msg' %> </p>
+
+<p><%= link_to t('.confirm_account_link'), confirmation_url(@resource, {confirmation_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url']}).html_safe %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
+
+<p><%= t '.request_reset_link_msg' %></p>
+
+<p><%= link_to t('.password_change_link'), edit_password_url(@resource, reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url'].to_s).html_safe %></p>
+
+<p><%= t '.ignore_mail_msg' %></p>
+<p><%= t '.no_changes_msg' %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,0 @@
-<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
-
-<p><%= t '.request_reset_link_msg' %></p>
-
-<p><%= link_to t('.password_change_link'), edit_password_url(@resource, reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url'].to_s).html_safe %></p>
-
-<p><%= t '.ignore_mail_msg' %></p>
-<p><%= t '.no_changes_msg' %></p>


### PR DESCRIPTION
## 例
@watasho358 @koki-takishita @tmhr0 

[link](https://dev.classmethod.jp/articles/pull-request-template/)

## チケットへのリンク

* https://example.com

## やったこと

* ケアマネの新規登録をするとケアマネ用の認証メールが届く

## やらないこと

*なし

## できるようになること（ユーザ目線）

ケアマネージャーの新規登録のリクエストを送るとケアマネージャー用のメールが届く

## できなくなること（ユーザ目線）

なし

## 動作確認

**カスタマー(customer)**
・動画
https://www.loom.com/share/d09d945c83e246b4adc5185b40d5c1b7
1.localhost:3000/api/usersにリクエスト送る

```
name: 任意
email: 任意
password: password
password_confirmation: password
post_code: 任意
address: 任意
phone_number: 任意
confirm_success_url: localhost:8000
```

2.メールキャッチャーにカスタマーと書かれたメールが飛んでくる

・PostmanからPost localhost:3000/api/users　にリクエストを送る
https://gyazo.com/56578c3cb5d9c870bd0091e0e2047aeb

・メールキャッチャーにカスタマーと書かれたメールが飛んでくる
https://gyazo.com/62b81d9541b0db91aaa4f500f390892d

**ケアマネ(specialists)**
・動画手順
https://www.loom.com/share/3dda126c119542e9b34eca7a3006c795
1.localhost:3000/api/specialists/usersにリクエスト送る

```
name: 任意
email: 任意
password: password
password_confirmation: password
post_code: 任意
address: 任意
phone_number: 任意
confirm_success_url: localhost:8000
```

2.メールキャッチャーにスペシャリストと書かれたメールが飛んでくる

・PostmanからPost localhost:3000/api/specialists/users にリクエストを送る
https://gyazo.com/c9dc17c3042e49ebe4fe096be354895c

・メールキャッチャーにスペシャリストと書かれたメールが飛んでくる
https://gyazo.com/f5c369d3275ac9392a99079dafeabc6e

## その他

修正点などあれば行ってください
