### PR TITLE
build: 休業日の曜日を格納するカラムの追加

### DIFF
--- a/db/migrate/20220517052740_add_selected_flags_to_offices.rb
+++ b/db/migrate/20220517052740_add_selected_flags_to_offices.rb
@@ -1,0 +1,5 @@
+class AddSelectedFlagsToOffices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :offices, :selected_flags, :string
+  end
+end


### PR DESCRIPTION
## やったこと

* 休業日の曜日を格納するカラムを追加
## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

- 事業所のデータがある場合、削除
```
> Office.destroy.all
```

* `rails db:migrate`後、`rails db:migrate:status`
```
--------------------------------------------------                
   up     20220509013022  Devise token auth create users          
   up     20220509083245  Add user type to users                  
   up     20220510060242  Create offices                          
   up     20220511080656  Create contacts
   up     20220516091139  Rename holiday to flags in offices
   up     20220517052740  Add selected flags to offices　  ← NEW！
```

- `rails db:seed` 実行（3人分のユーザが作られていることが前提）
- 選択済みの休業日を確認。find()には事業所のIDが入ります。
```
> Office.find(1).selected_flags
  Office Load (7.6ms)  SELECT "offices".* FROM "offices" WHERE "offices"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]                                                              
=> [:sunday, :wednesday] 
```

## その他

- フロントで曜日を受け取ったほうが営業日の判定が実装しやすいと思ったため、カラムを追加しました。
- これで、flagsに1、2、4、8、16、32、64のどの組み合わせの値を入れても、対応した曜日がselected_flagsに配列で入るようになります。事業所登録機能を実装するときは、曜日を選択して登録すると、flagsに数字が入り、事業所詳細画面でselected_flagsを受け取るようになると思います。