### PR TITLE
build: スタッフ登録(画像抜き)

### DIFF
--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -1,2 +1,16 @@
 class Api::Specialists::StaffsController < ApplicationController
+  def create
+    staff = Staff.new(staff_params)
+    if staff.valid?
+      staff.save!
+      render json: { status: 'success' }
+    else
+      render json: { status: staff.errors.full_messages }
+    end
+  end
+
+  private
+    def staff_params
+      params.permit(:office_id, :name, :kana, :introduction)
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :offices, only: [:index, :show]
+    namespace :specialists do
+      resources :staffs, only: [:create]
+    end
   end
   mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks], controllers: {
     registrations: 'api/overrides/registrations'


### PR DESCRIPTION
## やったこと

* スタッフ登録機能（画像抜き）

## やらないこと

* バリデーション（画像以外はフロント側で完結。）
* 画像登録（次のプルリク確認時間16:00までに間に合えば、追加でコミットし、伝えます。）

## できるようになること（ユーザ目線）

* スタッフの画像以外の情報をDBに保存できる

## できなくなること（ユーザ目線）

* 画像の登録

## 動作確認

- fetch後、checkout
```
$ git fetch
$ git ch origin/feature/スタッフ登録機能-画像抜き
```

- PostmanでPostリクエストを送る
https://www.postman.com/
```
【コピペ用】

http://localhost:3000/api/specialists/staffs
name  田中
kana  たなか
introduction  自己紹介
```
* `"status": "success"`と表示されているか確認
![image](https://user-images.githubusercontent.com/34031637/169195862-40e5ddd3-5dae-46f4-9615-feef12def62d.png)

- コンソール上でスタッフが登録されているか確認
```
$ docker-compose exec web bash
# rails c
> Staff.all
  Staff Load (5.1ms)  SELECT "staffs".* FROM "staffs"
=>                                                               
[#<Staff:0x0000ffff993a2c28                                      
  id: 1,                                                         
  office_id: 1,                                                  
  name: "田中",                                                  
  kana: "たなか",                                                
  introduction: "自己紹介",                                      
  created_at: Thu, 19 May 2022 11:52:10.513982000 JST +09:00,    
  updated_at: Thu, 19 May 2022 11:52:10.513982000 JST +09:00>]  
```

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
