### PR TITLE
【WIP】fix: スタッフエンドポイント修正

### DIFF
--- a/app/controllers/api/specialists/offices/staffs_controller.rb
+++ b/app/controllers/api/specialists/offices/staffs_controller.rb
@@ -1,4 +1,9 @@
 class Api::Specialists::StaffsController < ApplicationController
+  def index
+    staffs = Staff.all
+    render json: staffs
+  end
+
   def create
     staff = Staff.new(staff_params)
     if staff.valid?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   namespace :api do
     resources :offices, only: [:index, :show]
     namespace :specialists do
-      resources :staffs, only: [:create]
+      resources :offices do
+        resources :staffs, only: [:index, :create]
+      end
     end
   end
   mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks], controllers: {


### PR DESCRIPTION
## やったこと

* スタッフのエンドポイントがapi/specialists/staffsになっていたのでapi/specialists/offices/:id/staffs/に変更
* 事業所作成のAPIも追加（意図的ではなく自然に追加された）

## やらないこと

* indexアクションで事業所関係なくすべてのスタッフが取得できているところの修正（次スプリントで対応）

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* fetch後、ブランチ切り替え
```
git checkout
```
```
git checkout origin/feature/スタッフエンドポイント修正
```

- docker内に入り、ルートの一覧を確認
- スタッフのAPIが修正されていることと、事業所作成のAPIが追加されていることの確認
・スタッフ登録・一覧
・事業所作成・更新・削除
[API一覧　ケアマネ](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=1032659497)

```
docker-compose exec web bash
```
```
rails routes
```
![image](https://user-images.githubusercontent.com/34031637/169430991-d92552d0-ad28-4fd3-801d-ea998ce2cae7.png)