### PR TITLE
fix: ログイン・ログアウトルーティング修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,12 @@ Rails.application.routes.draw do
       resources :staffs, only: [:create]
     end
   end
-  mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks], controllers: {
+  mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks, :sessions], controllers: {
     registrations: 'api/overrides/registrations'
   }
   devise_scope :user do
     post 'api/specialists/users', to: 'api/overrides/specialist_registrations#create'
+    post   'api/login',           to: 'devise_token_auth/sessions#create'
+    delete 'api/logout',           to: 'devise_token_auth/sessions#destroy'
   end
 end


### PR DESCRIPTION
## やったこと
[API一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)
1. loginのエンドポイントAPI定義書どおりに修正
**左:変更前 右:修正後**
```ruby
api/users/sign_in → api/login
```
2. logoutのエンドポイントAPI定義書どおりに修正
```ruby
api/users/sign_out → api/logout
```

## やらないこと

フロントには未対応

## できるようになること（ユーザ目線）

エンドポイントが、定義書通りになる

## できなくなること（ユーザ目線）

フロントのパスをいじってないので、フロント側からログインはできなくなる

## 動作確認

1. 手順動画の手順で確認 **エンドポイント変わるので注意**
```ruby
docker-compose restart
# エンドポイント
http://localhost:3000/api/logout
# パラメーター 認証済みのユーザー
email
password
```
[手順動画](https://www.loom.com/share/f4a1eb32b51841499ad85c9c4d2710ba)

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
