### PR TITLE
build: スタッフ登録-画像あり

### DIFF
--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -1,9 +1,13 @@
 class Api::Specialists::StaffsController < ApplicationController
+  def index
+    staffs = Staff.all
+    render json: staffs, methods: [:image_url]
+  end
+
   def create
     staff = Staff.new(staff_params)
     if staff.valid?
       staff.save!
-      render json: { status: 'success' }
     else
       render json: { status: staff.errors.full_messages }
     end
@@ -11,6 +15,6 @@ class Api::Specialists::StaffsController < ApplicationController
 
   private
     def staff_params
-      params.permit(:office_id, :name, :kana, :introduction)
+      params.permit(:office_id, :name, :kana, :introduction, :image)
     end
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,4 +1,10 @@
 class Staff < ApplicationRecord
+  include Rails.application.routes.url_helpers
   has_many :office
   has_one_attached :image
+
+  def image_url
+      helpers = Rails.application.routes.url_helpers
+      helpers.url_for(image)
+  end
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -5,6 +5,10 @@ class Staff < ApplicationRecord
 
   def image_url
       helpers = Rails.application.routes.url_helpers
-      helpers.url_for(image)
+      if image.blank?
+        return
+      else
+        helpers.url_for(image)
+      end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,4 +65,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  
+  Rails.application.routes.default_url_options[:host] = 'localhost'
+  Rails.application.routes.default_url_options[:port] = 3000
 end


### PR DESCRIPTION
## やったこと

* スタッフ登録機能（画像あり）
* フロントから渡ってきた画像をローカルストレージに保存（storageフォルダに画像のメタデータが保存されます）
* モデルにメソッドを定義し画像のURLを発行・JSONで返す

## やらないこと

* 事業所ごとのスタッフを取得（今週は対応しない）
* S3へのアップロード（今週対応予定）
* 画像のリサイズ（必要に迫られたときに来週以降対応）

## できるようになること（ユーザ目線）

* スタッフの画像が登録できるようになる

## できなくなること（ユーザ目線）

* なし

## 動作確認

- fetch後、checkout
```
git fetch
```
```
git checkout origin/feature/スタッフ登録-画像あり
```

* [https://github.com/koki-takishita/home-care-navi-front/pull/83](https://github.com/koki-takishita/home-care-navi-front/pull/83)  　こちらの動作確認ですべて完結するようになっています

## その他
コンソールでも画像が保存できているか確認できます。
- docker内に入り、コンソールに入る
```
docker-compose exec web bash 
```
```
rails c
```
- スタッフの情報を全件取得し、目的のデータの画像データを取得する
```
> Staff.all


〜　findでID指定して検索します。ファイル名やバイトサイズなどの情報を取得できます　〜

> Staff.find(1).image_blob
（中略）                                                                
=>                                                                                                     
#<ActiveStorage::Blob:0x0000ffff87c7fa10
 id: 1,
 key: "96wenzgfaihya5eofy5m9upwsfvs",
 filename: "youngman_25.png",
 content_type: "image/png",
 metadata: {"identified"=>true, "analyzed"=>true},
 service_name: "local",
 byte_size: 24167,
 checksum: "1+wx5xIvPPIT/JUv1qi7Lw==",
 created_at: Wed, 25 May 2022 11:38:47.144918000 JST +09:00>

```