### PR TITLE
事業所登録機能　スタッフコントローラindexメソッド修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@
 /config/master.key
 /config/devise_secret_key.rb
 
-db/schema.rb
+# db/schema.rb

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -1,6 +1,5 @@
 class Api::OfficesController < ApplicationController
   before_action :set_office, only: [:show]
-  before_action :authenticate_specialist!
 
   def index
     offices = Office.all
@@ -11,22 +10,7 @@ class Api::OfficesController < ApplicationController
     render json:@office.as_json{ :@office }
   end
 
-  def create
-    params[:user_id] = current_specialist.id
-    office = Office.new(office_params)
-    if office.valid?
-      office.save!
-      render json: { status: 200}
-    else
-      render json: { status: office.errors.full_messages }
-    end
-  end
-
   private
-    def office_params
-    params.permit(:name, :title, :flags, :business_day_detail, :address, :post_code, :phone_number, :fax_number, :user_id, images: [])
-    end
-
     def set_office
       @office = Office.find(params[:id])
     end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -16,7 +16,7 @@ class Api::OfficesController < ApplicationController
     office = Office.new(office_params)
     if office.valid?
       office.save!
-      # puts "log::#{office_params}"
+      render json: { status: 200}
     else
       render json: { status: office.errors.full_messages }
     end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -1,5 +1,6 @@
 class Api::OfficesController < ApplicationController
   before_action :set_office, only: [:show]
+  before_action :authenticate_specialist!
 
   def index
     offices = Office.all
@@ -10,8 +11,22 @@ class Api::OfficesController < ApplicationController
     render json:@office.as_json{ :@office }
   end
 
+  def create
+    params[:user_id] = current_specialist.id
+    office = Office.new(office_params)
+    if office.valid?
+      office.save!
+    else
+      render json: { status: office.errors.full_messages }
+    end
+  end
+
   private
-   def set_office
+    def office_params
+    params.permit(:name, :title, :flags, :business_day_detail, :address, :post_code, :phone_number, :fax_number, :user_id, images: [])
+    end
+
+    def set_office
       @office = Office.find(params[:id])
-   end
+    end
 end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -16,7 +16,7 @@ class Api::OfficesController < ApplicationController
     office = Office.new(office_params)
     if office.valid?
       office.save!
-      # puts "log::#{office_params}"
+      puts "log::#{office_params}"
     else
       render json: { status: office.errors.full_messages }
     end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -16,7 +16,7 @@ class Api::OfficesController < ApplicationController
     office = Office.new(office_params)
     if office.valid?
       office.save!
-      puts "log::#{office_params}"
+      # puts "log::#{office_params}"
     else
       render json: { status: office.errors.full_messages }
     end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -16,6 +16,7 @@ class Api::OfficesController < ApplicationController
     office = Office.new(office_params)
     if office.valid?
       office.save!
+      # puts "log::#{office_params}"
     else
       render json: { status: office.errors.full_messages }
     end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -7,7 +7,7 @@ class Api::OfficesController < ApplicationController
   end
 
   def show
-    render json:@office.as_json{ :@office }
+    render json: @office, methods: [:image_url]
   end
 
   private

--- a/app/controllers/api/specialists/offices_controller.rb
+++ b/app/controllers/api/specialists/offices_controller.rb
@@ -8,7 +8,7 @@ class Api::Specialists::OfficesController < ApplicationController
       office.save!
       render json: { status: 200}
     else
-      render json: { status: office.errors.full_messages }
+      render status: 401, json: { errors: office.errors.full_messages }
     end
   end
 

--- a/app/controllers/api/specialists/offices_controller.rb
+++ b/app/controllers/api/specialists/offices_controller.rb
@@ -1,0 +1,19 @@
+class Api::Specialists::OfficesController < ApplicationController
+  before_action :authenticate_specialist!
+
+  def create
+    params[:user_id] = current_specialist.id
+    office = Office.new(office_params)
+    if office.valid?
+      office.save!
+      render json: { status: 200}
+    else
+      render json: { status: office.errors.full_messages }
+    end
+  end
+
+  private
+  def office_params
+    params.permit(:name, :title, :flags, :business_day_detail, :address, :post_code, :phone_number, :fax_number, :user_id, images: [])
+  end
+end

--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -3,7 +3,7 @@ class Api::Specialists::StaffsController < ApplicationController
     before_action :authenticate_specialist!
 
   def index
-    @staffs = Staff.where(office_id:params[:office_id])
+    @staffs = current_specialist.office.staffs
     render json: @staffs, methods: [:image_url]
   end
 

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,7 +1,17 @@
 class Office < ApplicationRecord
   include FlagShihTzu
-  belongs_to :user
-  has_many :staff
+  belongs_to :specialist, foreign_key: 'user_id', dependent: :destroy
+  has_many :staffs, dependent: :destroy
+  has_many_attached :images
+
+  def image_url
+    helpers = Rails.application.routes.url_helpers
+    if images.blank?
+      return
+    else
+      helpers.url_for(images)
+    end
+  end
 
   has_flags(
     1 => :sunday,

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,17 +1,8 @@
 class Office < ApplicationRecord
   include FlagShihTzu
-  belongs_to :specialist, foreign_key: 'user_id', dependent: :destroy
+  belongs_to :specialist, foreign_key: 'user_id'
   has_many :staffs, dependent: :destroy
   has_many_attached :images
-
-  def image_url
-    helpers = Rails.application.routes.url_helpers
-    if images.blank?
-      return
-    else
-      helpers.url_for(images)
-    end
-  end
 
   has_flags(
     1 => :sunday,

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -4,6 +4,8 @@ class Office < ApplicationRecord
   has_many :staffs, dependent: :destroy
   has_many_attached :images
 
+  validates :user_id, uniqueness: true
+
   def image_url
     helpers = Rails.application.routes.url_helpers
     if images.blank?

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -4,6 +4,15 @@ class Office < ApplicationRecord
   has_many :staffs, dependent: :destroy
   has_many_attached :images
 
+  def image_url
+    helpers = Rails.application.routes.url_helpers
+    if images.blank?
+      return
+    else
+      images.map{|image| helpers.url_for(image) }
+    end
+  end
+
   has_flags(
     1 => :sunday,
     2 => :monday,

--- a/app/models/specialist.rb
+++ b/app/models/specialist.rb
@@ -1,4 +1,5 @@
 class Specialist < User
+  has_one :office , foreign_key: "user_id", dependent: :destroy
   
   def set_user_type(type)
     set_specialist if type == :specialist

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,5 +1,5 @@
 class Staff < ApplicationRecord
-  has_many :office
+  belongs_to :office
   has_one_attached :image
 
   def image_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-
+  has_one :office , dependent: :destroy
+  
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :validatable, :confirmable
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,8 +30,12 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+      office:
+        user_id: 事業所
     models:
       user: 'ユーザ'
+    models:
+      office: '事業所'
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :contacts, only: [:create]
-    resources :offices, only: [:index, :show, :create]
+    resources :offices, only: [:index, :show]
   end
 
   mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks, :sessions], controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :contacts, only: [:create]
-    resources :offices, only: [:index, :show]
+    resources :offices, only: [:index, :show, :create]
   end
 
   mount_devise_token_auth_for 'User', at: 'api/users', skip: [:omniauth_callbacks, :sessions], controllers: {

--- a/db/migrate/20220511080656_create_contacts.rb
+++ b/db/migrate/20220511080656_create_contacts.rb
@@ -8,3 +8,4 @@ class CreateContacts < ActiveRecord::Migration[7.0]
       t.timestamps
     end
   end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,111 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_05_31_230946) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "contacts", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "types"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "offices", force: :cascade do |t|
+    t.string "name"
+    t.string "title"
+    t.integer "flags", default: 0, null: false
+    t.string "business_day_detail"
+    t.string "address"
+    t.string "post_code"
+    t.string "phone_number"
+    t.string "fax_number"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "selected_flags"
+    t.index ["user_id"], name: "index_offices_on_user_id"
+  end
+
+  create_table "staffs", force: :cascade do |t|
+    t.string "name"
+    t.string "kana"
+    t.string "introduction"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "office_id"
+    t.index ["office_id"], name: "index_staffs_on_office_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "phone_number"
+    t.string "post_code"
+    t.string "address"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_type", default: 0, null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "offices", "users"
+  add_foreign_key "staffs", "offices"
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,10 +43,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_31_230946) do
   end
 
   create_table "contacts", force: :cascade do |t|
-    t.string "name"
-    t.string "email"
-    t.string "types"
-    t.text "content"
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "types", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,39 +83,3 @@ if(specialist)
   puts "有効化済み? #{specialist.confirmed?}"
   puts "---------------------------------"
 end
-
-specialist.create_office!(
-  name:                'サンプルオフィス',
-  title:               'サンプルタイトル',
-  flags:               65,
-  address:             'サンプル県サンプル市サンプル町 1-1-1',
-  post_code:           '111-1111',
-  phone_number:        '111-1111-1111',
-  fax_number:          '111-1111-1111',
-  business_day_detail: '営業日の説明が入ります',
-)
-office = specialist.office
-if(office)
-  puts ""
-  puts "Officeサンプルデータ作成完了"
-  puts "---------------------------------"
-  puts "name #{office.name}"
-  puts "休日   #{office.selected_flags}"
-  puts "---------------------------------"
-end
-
-10.times {|n|
-  office.staffs.create!(
-    name:         "サンプルスタッフ#{n}",
-    kana:         "さんぷるすたっふ１",
-    introduction: "サンプルスタッフ#{n}の紹介文",
-  )
-}
-staffs = office.staffs
-if(staffs)
-  puts ""
-  puts "Staffsサンプルデータ作成完了"
-  puts "---------------------------------"
-  puts "作成したスタッフ数 #{staffs.count}"
-  puts "---------------------------------"
-end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,3 +83,39 @@ if(specialist)
   puts "有効化済み? #{specialist.confirmed?}"
   puts "---------------------------------"
 end
+
+specialist.create_office!(
+  name:                'サンプルオフィス',
+  title:               'サンプルタイトル',
+  flags:               65,
+  address:             'サンプル県サンプル市サンプル町 1-1-1',
+  post_code:           '111-1111',
+  phone_number:        '111-1111-1111',
+  fax_number:          '111-1111-1111',
+  business_day_detail: '営業日の説明が入ります',
+)
+office = specialist.office
+if(office)
+  puts ""
+  puts "Officeサンプルデータ作成完了"
+  puts "---------------------------------"
+  puts "name #{office.name}"
+  puts "休日   #{office.selected_flags}"
+  puts "---------------------------------"
+end
+
+10.times {|n|
+  office.staffs.create!(
+    name:         "サンプルスタッフ#{n}",
+    kana:         "さんぷるすたっふ１",
+    introduction: "サンプルスタッフ#{n}の紹介文",
+  )
+}
+staffs = office.staffs
+if(staffs)
+  puts ""
+  puts "Staffsサンプルデータ作成完了"
+  puts "---------------------------------"
+  puts "作成したスタッフ数 #{staffs.count}"
+  puts "---------------------------------"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,17 +5,81 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
-Office.create(name: 'ホームケアナビ佐渡1ホームケアナビ佐渡1', title: '事業所タイトル1事業所タイトル1', flags: '9', business_day_detail:'営業日の説明が入ります営業日の説明が入ります', address:'東京都中央区入船3-9-1第二細矢ビル1階', post_code:'001-0001', phone_number:'0001-01-0001', fax_number:'096-273-8765', user_id:'1', )
-Office.create(name: 'ホームケアナビ佐渡2ホームケアナビ佐渡2', title: '事業所タイトル2事業所タイトル2', flags: '8', business_day_detail:'営業日の説明が入ります営業日の説明が入ります', address:'東京都中央区新川2-27-3', post_code:'002-0002', phone_number:'0002-02-0002', fax_number:'090-145-5678', user_id:'2', )
-Office.create(name: 'ホームケアナビ佐渡3ホームケアナビ佐渡3', title: '事業所タイトル3事業所タイトル3', flags: '96', business_day_detail:'営業日の説明が入ります営業日の説明が入ります', address:'東京都中央区明石町1-6', post_code:'003-0003', phone_number:'0003-03-0003', fax_number:'050-687-2915', user_id:'3', )
+# tables = ["User", "Office", "Staff", "Contact"]
+puts "テーブル全削除処理スタート"
+User.destroy_all
+Office.destroy_all
+Staff.destroy_all
+Contact.destroy_all
+puts "テーブル全削除完了"
 
-10.times do |n|
-  staff = Staff.create!(
-  office_id: '1',
-  name: "スタッフ#{n+1}",
-  kana: "すたっふ",
-  introduction: "スタッフ#{n+1}の紹介文です",
- )
- staff.image.attach(io: File.open(Rails.root.join('public/images/youngman_27.png')),
-filename: 'youngman_27.png')
+User.create!(
+  name:                     'カスタマー',
+  password:                 'password',
+  password_confirmation:    'password',
+  phone_number:             '000-0000-0000',
+  post_code:                '111-1111',
+  email:                    'customer@example.com',
+  address:                  'カスタマ県カスタマ市カスタマ町 1-1-1',
+  user_type:                'customer'
+)
+user = User.first
+user.confirm
+if(user)
+  puts ""
+  puts "Userサンプルデータ作成完了"
+  puts "---------------------------------"
+  puts "email       #{user.email}"
+  puts "password    password"
+  puts "user_type   #{user.user_type}"
+  puts "有効化済み? #{user.confirmed?}"
+  puts "---------------------------------"
+end
+
+User.create!(
+  name:                     'カスタマー',
+  password:                 'password',
+  password_confirmation:    'password',
+  phone_number:             '000-0000-0001',
+  post_code:                '111-1111',
+  email:                    'customer2@example.com',
+  address:                  'カスタマ県カスタマ市カスタマ町 1-1-2',
+  user_type:                'customer'
+)
+user2 = User.second
+if(user)
+  puts ""
+  puts "Userサンプルデータ作成完了"
+  puts "---------------------------------"
+  puts "email       #{user2.email}"
+  puts "password    password"
+  puts "user_type   #{user2.user_type}"
+  puts "有効化済み? #{user2.confirmed?}"
+  puts "---------------------------------"
+end
+
+
+Specialist.create!(
+  name:                     'スペシャリスト',
+  password:                 'password',
+  password_confirmation:    'password',
+  phone_number:             '000-0000-1111',
+  post_code:                '111-1111',
+  email:                    'specialist@example.com',
+  address:                  'スペシャリスト県スペシャリスト市スペシャリスト町 1-1-1',
+  user_type:                'specialist'
+)
+
+specialist = Specialist.third
+specialist.specialist!
+specialist.confirm
+if(specialist)
+  puts ""
+  puts "Specialistサンプルデータ作成完了"
+  puts "---------------------------------"
+  puts "email       #{specialist.email}"
+  puts "password    password"
+  puts "user_type   #{specialist.user_type}"
+  puts "有効化済み? #{specialist.confirmed?}"
+  puts "---------------------------------"
 end


### PR DESCRIPTION
## やったこと

- スペシャリスト・スタッフ・事業所の関連付け
- seedでユーザー・スペシャリストを作成できるようにした
- 事業所テーブルのcreateメソッド作成・ActiveStorage紐付け
- スタッフコントローラindexメソッド修正
- 事業所詳細 事業所画像取得 

## やらないこと

- 事業所・スタッフをseedで作成すること

## できるようになること（ユーザ目線）

- 事業所登録ができるようになる

## できなくなること（ユーザ目線）

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/office_create
```

- コンテナ入る

```ruby
docker-compose exec web bash
```
- seed 実行
```ruby
rails db:seed
```
- ユーザー・スペシャリストのデータ確認
```
User.all
```
### 動作確認
- ケアマネでログインし、事業所登録画面で事業所登録をすませる
https://github.com/koki-takishita/home-care-navi-front/pull/126
### Loom 手順
- Headers
```ruby
client
expiry
uid
access-token
```
- 事業所登録後、コンソールに入って事業所のIDを確認する
```
docker-compose exec web bash
rails c
Office.all
```
```ruby
http://localhost:3000/api/offices/<事業所ID>
```
[Postman 手順動画](https://www.loom.com/share/f72a6b5bc3284ea2bf58a119fdec290b)

## その他

- 確認してほしいシナリオテスト
8.5 事業所詳細画面に行く
２１．16からケアマネがスタッフ登録
２２．16からケアマネがスタッフ編集
２２．16からケアマネがスタッフ削除
[シナリオテスト一覧](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1509308895)
