### PR TITLE
ログイン後のヘッダー編集

### DIFF
--- a/app/controllers/api/overrides/customer/sessions_controller.rb
+++ b/app/controllers/api/overrides/customer/sessions_controller.rb
@@ -5,6 +5,7 @@ module Api
         before_action  :configure_permitted_parameters
         before_action  :exclusion_login_specialist, if: -> { params[:user_type] == 'customer' }
         before_action  :exclusion_login_customer, if: -> { params[:user_type] == 'specialist' }
+        after_action  :add_office_data, if: -> { params[:user_type] == 'specialist' }
        
         private
 
@@ -16,6 +17,13 @@ module Api
         def  exclusion_login_customer
           user = User.find_by(email: params[:email])
           render_create_error_forbidden if user && user.customer?
+        end
+
+        def  add_office_data
+          user = User.find_by(email: params[:email])
+          if !user.office.nil? 
+            response.headers['office_data'] = 'true'
+          end
         end
 
         def render_create_error_forbidden

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,5 +11,5 @@ class User < ApplicationRecord
   validates :name, :phone_number, :post_code, :address, :email, presence: true
   validates :phone_number, uniqueness: true
 
-  has_one :office
+  has_one :office, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
   validates :name, :phone_number, :post_code, :address, :email, presence: true
   validates :phone_number, uniqueness: true
 
+  has_one :office
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,7 +10,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins 'localhost:8000'
     resource '*',
       headers: :any,
-      expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
+      expose: ['access-token', 'expiry', 'token-type', 'uid', 'client', 'office_data'],
       methods: [:get, :post, :options, :delete, :put]
   end
 end


### PR DESCRIPTION
## やったこと

### ケアマネログインのヘッダー編集
1.ケアマネージャーログイン後のヘッダーレイアウト
2.ログイン時事業所を持っていれば、事業所編集を表示。持っていなければ、事業所登録を表示

## やらないこと

* ヘッダーのリンクの遷移先（各担当の方設定お願いします）

## できるようになること（ユーザ目線）

* レイアウトがすっきりしてみやすくなる
* 事業所を登録してないときは登録が表示されて、登録してる時は編集が表示される

## できなくなること（ユーザ目線）

* 特になし

## 動作確認

### API 側

- ドッカーリスタート

```ruby
docker compose restart
```

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/specialists_login
```

### フロント 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/specialist-header
```

## 事業所持っていないケアマネの確認手順

1,rails db seedを実行
2,ケアマネログインページ `http://localhost:8000/specialists/login`からログイン
```
メールアドレス　specialist@example.com
パスワード　password
```
3.メニューを開き『事業所登録』があることを確認

## 事業所持っていないケアマネの確認手順
4.事業所を登録
5.ログアウト
6.再度ログイン
7.メニューを開く
8.事業所を登録したので、メニューを開く事業所編集になっている

[手順動画](https://www.loom.com/share/c850f23300cc4898b17784a729794ed4)

## その他

フロントとAPI合わせて確認お願いします
