### PR TITLE
存在しないユーザーがログイン時のエラー修正

### DIFF
--- a/app/controllers/api/overrides/customer/sessions_controller.rb
+++ b/app/controllers/api/overrides/customer/sessions_controller.rb
@@ -21,7 +21,7 @@ module Api
 
         def  add_office_data
           user = User.find_by(email: params[:email])
-          if !user.office.nil? 
+          if user && !user.office.nil?
             response.headers['office_data'] = 'true'
           end
         end


### PR DESCRIPTION
## やったこと

存在しないユーザーがログインしようとする時に『サーバー側のエラーです』と表示されてしまうバグの修正を行なった

## できるようになること（ユーザ目線）

* 存在しないユーザーがログインしようとすると『ログイン用の認証情報が正しくありません。再度お試しください。』と表示される


## 動作確認
### API 側

- fetch and checkout 

```ruby
git fetch && git checkout origin/suwonkun-patch-1
```

手順1.`http://localhost:8000/specialists/login`に移動
手順2.フォームに存在しない値入力
手順3.『ログイン用の認証情報が正しくありません。再度お試しください。』と表示される

以前
https://gyazo.com/dc8f19d447fea12ef555fd3317482f49

編集後
https://gyazo.com/7ea0870b625e312575ef144d38e4c4c5

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
