### PR TITLE
ユーザーの予約履歴を返す

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,82 @@
-## 例
-
-[link](https://dev.classmethod.jp/articles/pull-request-template/)
-
-## チケットへのリンク
-
-* https://example.com
-
 ## やったこと
 
-* このプルリクで何をしたのか？
+- このプルリクで何をしたのか？
 
 ## やらないこと
 
-* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
+- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。）
 
 ## できるようになること（ユーザ目線）
 
-* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
+- 何ができるようになるのか？（あれば。無いなら「無し」で OK）
 
 ## できなくなること（ユーザ目線）
 
-* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
+- 何ができなくなるのか？（あれば。無いなら「無し」で OK）
 
-## 動作確認
+# **必要なかったら消すこと**
 
-* どのような動作確認を行ったのか？　結果はどうか？
+### API 側
+
+- fetch and checkout
+
+```ruby
+git fetch && git checkout origin/feature/<ここを変える>
+```
+
+# **必要なかったら消すこと**
+
+### Front 側
+
+- fetch and checkout
+
+```ruby
+git fetch && git checkout origin/feature/<ここを変える>
+```
+
+# **必要なかったら消すこと**
+
+### docker compose
+
+- build
+
+```ruby
+docker-compose build
+```
+
+- コンテナリスタート
+
+```ruby
+docker-compose restart
+```
+
+- コンテナ入る
+
+```ruby
+docker-compose exec web bash
+```
+
+- コンソール入る
+
+```ruby
+rails c
+```
+
+### 動作確認 Loom 手順
+
+- 〇〇をする
+  [手順動画](urlが入る)
+
+### 確認書類
+
+# **必要なかったら消すこと**
+
+[画面図 url は該当のやつに変えること](https://xd.adobe.com/view/fbf6c289-81b2-4a4c-80fe-12a68930cc3b-aea5/grid/)
+[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)
+[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)
+[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)
+[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)
 
 ## その他
 
-* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
+- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -1,0 +1,10 @@
+class Api::AppointmentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @appointments = Appointment.where(user_id: current_user.id)
+    @office_id = current_user.appointments.pluck(:office_id)
+    offices = Office.find(@office_id)
+    render json: offices.to_json(:include => [:appointments], methods: [:image_url])
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,8 +1,6 @@
 class Appointment < ApplicationRecord
   has_one :office
   has_one :user
-
-  validates :user_id, uniqueness: true
   
   enum called_status: { need_call: 0, called: 1, cancel: 2 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :contacts, only: [:create]
+    resources :appointments, only: [:index]
     resources :offices, only: [:index, :show]
     resources :offices do
       resources :appointments, controller: 'offices/appointments', only: [:create]

--- a/db/migrate/20220620125926_change_appointments_meet_date_to_date.rb
+++ b/db/migrate/20220620125926_change_appointments_meet_date_to_date.rb
@@ -1,0 +1,9 @@
+class ChangeAppointmentsMeetDateToDate < ActiveRecord::Migration[7.0]
+  def up
+    change_column :appointments, :meet_date, 'date USING CAST(meet_date AS date)'
+  end
+
+  def down
+    change_column :appointments, :meet_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_15_050702) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_20_125926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_050702) do
 
   create_table "appointments", force: :cascade do |t|
     t.bigint "office_id"
-    t.string "meet_date"
+    t.date "meet_date"
     t.string "meet_time"
     t.string "name"
     t.string "age"
@@ -56,6 +56,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_050702) do
     t.datetime "updated_at", null: false
     t.index ["office_id"], name: "index_appointments_on_office_id"
     t.index ["user_id"], name: "index_appointments_on_user_id"
+  end
+
+  create_table "care_recipients", force: :cascade do |t|
+    t.string "name"
+    t.string "kana"
+    t.integer "age"
+    t.string "post_code"
+    t.string "address"
+    t.string "family"
+    t.bigint "office_id"
+    t.bigint "staff_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["office_id"], name: "index_care_recipients_on_office_id"
+    t.index ["staff_id"], name: "index_care_recipients_on_staff_id"
   end
 
   create_table "contacts", force: :cascade do |t|
@@ -152,6 +167,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_15_050702) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "appointments", "offices"
   add_foreign_key "appointments", "users"
+  add_foreign_key "care_recipients", "offices"
+  add_foreign_key "care_recipients", "staffs"
   add_foreign_key "office_details", "offices"
   add_foreign_key "offices", "users"
   add_foreign_key "staffs", "offices"


### PR DESCRIPTION
## やったこと

- 面談希望日時をstring型からdate型に変更
- ユーザーの予約履歴を返すindexメソッド実装

## やらないこと

- 予約履歴がないときにメッセージを返す（フロントで制御）

## できるようになること（ユーザ目線）

- ユーザーの予約履歴が見れる

## できなくなること（ユーザ目線）

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointments_index
```

- コンテナリスタート

```ruby
docker-compose restart
```
### 動作確認 Loom 手順

- コンテナ入る

```ruby
docker-compose exec web bash
```

- コンソール入る

```ruby
rails c
```
- 予約のデータをすべて消す
```ruby
Appointment.destroy_all
```
- コンテナ内に戻り、マイグレーション実行
```ruby
rails db:migrate
```
- マイグレートのステータス確認
```ruby
rails db:migrate:status
```
```ruby
Status   Migration ID    Migration Name                               
--------------------------------------------------                     
   up     20220509013022  Devise token auth create users               
   up     20220509083245  Add user type to users                       
   up     20220510060242  Create offices                               
   up     20220511080656  Create contacts                              
   up     20220516091139  Rename holiday to flags in offices           
   up     20220517052740  Add selected flags to offices                
   up     20220518035139  Create staffs                                
   up     20220518050442  Create active storage tablesactive storage   
   up     20220528113639  Change staff office id to references         
   up     20220531230946  Change contacts types to integer
   up     20220607114222  Create care recipients
   up     20220608034747  Rename offices column to care recipients
   up     20220608035604  Rename staffs column to care recipients
   up     20220608060022  Create thanks
   up     20220608064154  Create office details
   up     20220615050702  Create appointments
   up     20220620125926  Change appointments meet date to date
```
- コンソールに入り、面談希望日時がdate型に変更されているか確認
```ruby
Appointment.columns_hash['meet_date'].type
```
- フロントでWEB予約を済ませる
http://localhost:8000/offices/<オフィスID>
**WEB予約する**ボタンから予約する
- Railsで登録されたデータの確認
```ruby
Appointment.first
```
date型で登録されていればOK
```ruby
 meet_date: Thu, 23 Jun 2022,
```
- Postmanで予約履歴を取得

[ユーザー 予約履歴 Postman 確認動画](https://www.loom.com/share/afc6397854d546fcb9fed7e3b5fae2a4)
### 確認書類

[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)

## その他
### データの構造
- 事業所N
- 事業所Nの画像複数
- 事業所Nに紐づく予約複数

### フロントでの取得
- ユーザーが同じ事業所に複数回予約をした場合も履歴に残る
![image](https://user-images.githubusercontent.com/34031637/174702436-e2979929-4fc8-447b-bbd5-12ad7e0cdfe8.png)

