### PR TITLE
【修正】予約履歴APIでスタッフも取得する

### DIFF
--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -5,6 +5,6 @@ class Api::AppointmentsController < ApplicationController
     @appointments = Appointment.where(user_id: current_user.id)
     @office_id = current_user.appointments.pluck(:office_id)
     offices = Office.find(@office_id)
-    render json: offices.to_json(:include => [:appointments], methods: [:image_url])
+    render json: offices.to_json(:include => [:appointments, :staffs], methods: [:image_url])
   end
 end


### PR DESCRIPTION
## やったこと

- 予約履歴のAPIで、事業所に紐づくスタッフも取得するようにした

## やらないこと

- なし

## できるようになること（ユーザ目線）

- フロントでスタッフ数をカウントできる

## できなくなること（ユーザ目線）

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointments_index
```
### 動作確認 Loom 手順

- Postmanで予約履歴を取得する。スタッフが取得できているか確認する
```ruby
localhost:3000/api/appointments
```
![image](https://user-images.githubusercontent.com/34031637/174733626-a36c7d23-9b15-4f89-8c35-b6b2cdeea92e.png)


