### PR TITLE
5000のダミーオフィスを作成できる seedデータ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-
 gem 'devise', '~> 4.8', '>= 4.8.1'
 gem 'devise_token_auth', '>= 1.2.0', git: "https://github.com/lynndylanhurley/devise_token_auth"
 gem 'activerecord-like', git: "https://github.com/ReneB/activerecord-like"
@@ -45,6 +44,8 @@ gem 'flag_shih_tzu'
 
 gem "aws-sdk-s3", require: false
 
+# seedを使いやすくする https://rubygems.org/gems/seedbank
+gem 'seedbank', '~> 0.5.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
     rubocop-rspec (2.9.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    seedbank (0.5.0)
+      rake (>= 10.0)
     strscan (3.0.1)
     thor (1.2.1)
     timeout (0.2.0)
@@ -285,6 +287,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  seedbank (~> 0.5.0)
   tzinfo-data
 
 RUBY VERSION

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -34,18 +34,24 @@ class Api::OfficesController < ApplicationController
       #set_offices(search_sql, params[:prefecture], cities)
       search_area_offices(search_sql, params[:prefecture], cities).limit(10).offset(params[:page].to_i * 10)
     elsif(keywords_exist?)
-      keyword = to_like(params[:keywords])
-      post_cord = (params[:postCodes])
+      keyword = partial_match(params[:keywords])
+      post_cord = exact_match(params[:postCodes])
       search_keywords_offices(keyword, post_cord).limit(10).offset(params[:page].to_i * 10)
     else
       return []
     end
   end
 
-  def to_like(string)
+  def partial_match(string)
     return if(string.nil?)
     arry = string.split(',')
     result = arry.map{|ele| "%#{ele}%" }
+  end
+
+  def exact_match(string)
+    return if(string.nil?)
+    arry = string.split(',')
+    result = arry.map{|ele| "#{ele}" }
   end
 
   def keywords_exist?

--- a/db/dummy_files/dummy.csv
+++ b/db/dummy_files/dummy.csv
@@ -1,4 +1,4 @@
-﻿last_name,first_name,kana_last_name,kana_first_name,age,birth_day,gender,blod,email,tel_number,phone_number,post_code,address,company,credit,credit_deadline,my_number
+﻿last_name,first_name,last_name_kana,first_name_kana,age,birth_day,gender,blod,email,tel_number,phone_number,post_code,address,company,credit,credit_deadline,my_number
 馬渡,亜耶子,まわたり,あやこ,91,1930年06月29日,女,B,mawatari_ayako@example.net,03-5293-4548,080-2351-4622,117-7079,東京都西東京市富士町2丁目2番地5号,株式会社SKY,5320015839129111,09/24,004334672897
 澤田,慶,さわだ,けい,115,1906年07月28日,男,B,kei_sawada@example.net,03-9189-3099,070-1247-5621,164-6178,東京都世田谷区用賀3丁目1番地6号,有限会社伊藤製作所,3582750558589230,09/25,845945647744
 西岡,由美子,にしおか,ゆみこ,105,1916年08月08日,女,A,yumiko_nishioka@example.com,0564-65-5726,090-6142-0844,444-7810,愛知県名古屋市瑞穂区船原町2-4-13,株式会社北斗,376344021035405,05/24,469833405703

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,3 @@
-=begin
-require "csv"
-CSV.foreach("db/dummy_files/dummy.csv", headers: true) do |row|
-  #p row.headers
-end
-=end
-
 puts "テーブル全削除処理スタート"
 exclusion_tables = [
   'active_storage_variant_records',
@@ -36,13 +29,12 @@ puts !flag ? "テーブル全削除完了" : "Destroy Error 削除できてな�
     phone_number:          "000-0000-000#{n}",
     post_code:             '0000000',
     address:               '東京都千代田区丸の内1-1-1',)}
-user = User.first
-user.confirm
-if(User.count == 2)
+if(Customer.count == 2)
   puts ""
-  puts "Userサンプルデータ作成完了"
+  puts "カスタマーサンプルデータ作成完了"
   puts "---------------------------------"
-  User.all.each{|user|
+  Customer.all.each{|user|
+    user.confirm
     puts "email       #{user.email}"
     puts "password    password"
     puts "user_type   #{user.user_type}"
@@ -50,7 +42,7 @@ if(User.count == 2)
     puts "---------------------------------"
   }
 else
-  puts "User作成失敗"
+  puts "カスタマー作成失敗"
 end
 
 30.times{|n|
@@ -62,16 +54,12 @@ end
     phone_number:          "100-0000-000#{n + 3}",
     post_code:             '0000000',
     address:               '東京都千代田区丸の内1-1-1',)}
-specialist = Specialist.third
-specialist2 = Specialist.last
-specialist.confirm
-specialist2.confirm
-Specialist.offset(2).each{|s| s.confirm}
-if(Specialist.offset(2).count == 30)
+if(Specialist.count == 30)
   puts ""
   puts "Specialistサンプルデータ作成完了"
   puts "---------------------------------"
-  Specialist.offset(2).each{|user|
+  Specialist.all.each{|user|
+    user.confirm
     puts "email       #{user.email}"
     puts "password    password"
     puts "user_type   #{user.user_type}"
@@ -129,7 +117,7 @@ Specialist.all.each_with_index {|s, i|
     title:               "サンプルタイトル-#{i}",
     flags:               "#{i}",
     address:             address[i],
-    post_code:           "111111#{i}",
+    post_code:           "111111#{rand(1..9)}",
     phone_number:        "111-1111-112#{i}",
     fax_number:          '111-1111-1111',
     business_day_detail: '営業日の説明が入ります')

--- a/db/seeds/dummy_office.seeds.rb
+++ b/db/seeds/dummy_office.seeds.rb
@@ -1,0 +1,31 @@
+require "csv"
+CSV.foreach("db/dummy_files/dummy.csv", headers: true) do |row|
+  first_name      = row['first_name']
+  last_name       = row[0]
+  first_name_kana = row['first_name_kana']
+  last_name_kana  = row['last_name_kana']
+  age             = row['age']
+  birth_day       = row['birth_day']
+  gender          = row['gender']
+  blod            = row['blod']
+  email           = row['email']
+  tel_number      = row['tel_number']
+  fax_number      = row['phone_number']
+  post_code       = row['post_code']
+  address         = row['address']
+  company         = row['company']
+  credit          = row['credit']
+  credit_deadline = row['credit_deadline']
+  my_number       = row['my_number']
+
+  Office.create{|office|
+		office.name  		    = company
+		office.title 		    = "#{company}は最高のケアマネ事務所である理由"
+		office.flags 		    = rand(1..127)
+		office.address      = address
+		office.post_code    = post_code
+		office.phone_number = tel_number
+		office.fax_number   = fax_number
+		office.business_day_detail = "営業日に関する説明営業日に関する説明"
+	}
+end


### PR DESCRIPTION
## やったこと

1. officeのシードデータ作成
2. officeのバリテーションルール変更
3. seedの管理を楽にしてくれるgem導入

## やらないこと

user_idがnilのオフィスに対して、ケアマネを登録するような機能

## できるようになること（ユーザ目線）

- 本物っぽいダミーデータを作成できる
- シードファイルを複数もてるようになる

## できなくなること（ユーザ目線）

- なし

## 動作確認
### git fetch checkout
```ruby
git fetch && git checkout origin/feature/crate-dummy
```
### docker build && up
```ruby
docker compose down

# gem install したので
docker build

docker compose up -d

# コンテナはいる
docker compose exec web bash

rails db:seed:dummy_office

# 完了後オフィスが5000個以上あることを確認する
rails c

Office.count
=> 50??
```
### gemの使い方
[gem url](https://github.com/james2m/seedbank/)
下記公式の内容をそのまま持ってきてますが、これが全てですので使用する時は参照してください。  
このgemの入れることで、特定のseedファイルのみ実行することができるようになります。  
例えばテストのときだけ使うアカウントを定義できたりできるかもしれません
```linux
rake db:seed                    # Load the seed data from db/seeds.rb, db/seeds/*.seeds.rb and db/seeds/ENVIRONMENT/*.seeds.rb. ENVIRONMENT is the current environment in Rails.env.
rake db:seed:bar                # Load the seed data from db/seeds/bar.seeds.rb
rake db:seed:common             # Load the seed data from db/seeds.rb and db/seeds/*.seeds.rb.
rake db:seed:development        # Load the seed data from db/seeds.rb, db/seeds/*.seeds.rb and db/seeds/development/*.seeds.rb.
rake db:seed:development:users  # Load the seed data from db/seeds/development/users.seeds.rb
rake db:seed:original           # Load the seed data from db/seeds.rb
```

今回指示のあるこちらのコマンドは特定のseedファイルを実行していることになります。
```ruby
rails db:seed:dummy_office
```

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
