### PR TITLE
テストサーバー cors設定

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:8000'
+    origins 'localhost:8000', 'localhost:9000'
     resource '*',
       headers: :any,
       expose: ['access-token', 'expiry', 'token-type', 'uid', 'client', 'office_data'],


### PR DESCRIPTION
## やったこと

- テストサーバー(**localhost:9000**)からaxios通信をできるようにした

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/set-testServer-cors
```

- コンテナリスタート

```ruby
docker-compose restart
```

### 動作確認 Loom 手順
- コンテナリスタートまで行ったら、こちらのプルリクを確認してください
https://github.com/koki-takishita/home-care-navi-front/pull/162