### PR TITLE
build: 予約データの並び替え 予約seed修正

### DIFF
--- a/app/controllers/api/appointments_controller.rb
+++ b/app/controllers/api/appointments_controller.rb
@@ -5,6 +5,37 @@ class Api::AppointmentsController < ApplicationController
     @appointments = Appointment.where(user_id: current_user.id)
     @office_id = current_user.appointments.pluck(:office_id)
     offices = Office.find(@office_id)
-    render json: offices.to_json(:include => [:appointments, :staffs], methods: [:image_url])
+    sort_offices = []
+    appointments_created_ats = []
+    appointments_created_ats = sort_appointments_created_at(offices)
+    sort_offices = sort_office_appointments(appointments_created_ats)
+    offices = sort_offices.flatten
+
+    render json: offices,:include => {:appointments => {:only => [:meet_date, :meet_time, :called_status, :created_at]}, :staffs => {:only => [:id]}}, methods: [:image_url]
+  end
+
+private
+  # オフィスごとの予約作成日を取得し、日付が新しい順にソート
+  def sort_appointments_created_at(offices)
+    array = []
+    offices.each do |office|
+      created_at = office.appointments.last.created_at
+      array.push(created_at)
+    end
+    appointments_created_ats = array.sort {|a, b|
+      a <=> b
+    }.reverse
+    return appointments_created_ats
+  end
+
+  # オフィスを、予約作成日が新しい順に配列に追加する
+  def sort_office_appointments(appointments_created_ats)
+    array = []
+    appointments_created_ats.each do |appointments_created_at|
+      appointments_array = Appointment.where(created_at: appointments_created_at)
+      appointments_office_id = appointments_array.pluck(:office_id)
+      array.push(Office.find(appointments_office_id))
+    end
+    return array
   end
 end

--- a/app/controllers/api/specialists/appointments_controller.rb
+++ b/app/controllers/api/specialists/appointments_controller.rb
@@ -3,9 +3,10 @@ class Api::Specialists::AppointmentsController < ApplicationController
   before_action :set_office_appointment, only: [:update, :destroy]
 
   def index
-    data_length = current_specialist.office.appointments.length
-    @appointments = current_specialist.office.appointments.limit(10).offset(params[:page].to_i * 10)
-    render json: { appointments: @appointments, data_length: data_length }
+    @data_length = current_specialist.office.appointments.length
+    @order_called_status = current_specialist.office.appointments.order(:called_status)
+    @appointments = @order_called_status.limit(10).offset(params[:page].to_i * 10)
+    render json: { appointments: @appointments, data_length: @data_length }
   end
 
   def update

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -164,11 +164,13 @@ if(office_detail)
 end
 
 # 顧客が予約を作成
-office    = User.third.office
+office = Specialist.first.office
 office_id = office.id
-customer  = User.first
 from = Time.parse("2023/01/01")
 to = Time.parse("2023/12/31")
+timezone_from = Time.zone.parse('2010-01-01 00:00:00')
+timezone_to   = Time.zone.parse('2021-12-31 00:00:00')
+## 様々なユーザーが事業所に予約をする
 20.times {|n|
   office.appointments.create!(
     office_id:     office_id,
@@ -177,23 +179,43 @@ to = Time.parse("2023/12/31")
     meet_time:     "18:00〜20:00",
     phone_number:  "000-00#{n}-0000",
     age:           Random.rand(60..120),
-    user_id:       customer.id,
+    user_id:       Random.rand(Customer.first.id..Customer.last.id),
     comment:       "お困りごと#{n}",
-    called_status: Random.rand(0..2)
+    called_status: Random.rand(0..2),
+    created_at: rand(timezone_from..timezone_to)
   )
 }
-appointments = office.appointments
-appointments.each{|appt|
-  if(appt)
-    puts ""
-    puts "appointmentsサンプルデータ作成完了"
-    puts "---------------------------------"
-    puts "予約した事業所名  #{appt.office.name}"
-    puts "利用者名         #{appt.name}"
-    puts "連絡済み?        #{appt.called_status}"
-    puts "---------------------------------"
-  end
+## 特定のユーザーが様々な事業所に予約をする
+5.times {|n|
+  office = Specialist.find(Random.rand(Specialist.first.id..Specialist.last.id)).office
+  office_id = office.id
+  office.appointments.create!(
+    office_id:     office_id,
+    name:          "利用者#{n}",
+    meet_date:     Random.rand(from..to),
+    meet_time:     "18:00〜20:00",
+    phone_number:  "000-00#{n}-0000",
+    age:           Random.rand(60..120),
+    user_id:       Customer.first.id,
+    comment:       "お困りごと#{n}",
+    called_status: Random.rand(0..2),
+    created_at: rand(timezone_from..timezone_to)
+  )
 }
+if(Appointment.count == 25)
+  puts ""
+  puts ""
+  puts "Appointmentsサンプルデータ作成完了"
+  puts "---------------------------------"
+  puts "作成した予約数 #{Appointment.count}"
+  puts "---------------------------------"
+else
+  puts ""
+  puts ""
+  puts "Appointmentsサンプルデータ作成失敗"
+  puts ""
+  puts ""
+end
 
 # 顧客がお礼を作成
 office    = Office.first


### PR DESCRIPTION
## やったこと

- 予約データの並び替え
  - 予約履歴では、予約した日時順
  - 予約状況確認画面では、未連絡のものが先頭に来る
- 予約のseedの見直し

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointments-sort
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/appointments-sort
```

- コンテナ入る

```ruby
docker-compose exec web bash
```
- seed実行（rails:db:seedでも問題ないですが、今回は5000件のオフィスがなくても動作確認できるため、スピード優先で下記のコマンドを使用します）
```ruby
rails db:seed:original
```
- ターミナルにこのように表示されればOK
```ruby
.
.
Appointmentsサンプルデータ作成完了
作成した予約数 25
.
.

```
- こちらのプルリクを確認お願いします
https://github.com/koki-takishita/home-care-navi-front/pull/172

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
