### PR TITLE
スタッフ紹介ページに対応できるようにjsonの形修正

### DIFF
--- a/app/controllers/api/customer/offices_controller.rb
+++ b/app/controllers/api/customer/offices_controller.rb
@@ -13,11 +13,9 @@ class Api::Customer::OfficesController < ApplicationController
 
   def show
     staffs = add_image_h(@staffs)
-    thanks = build_thanks_hash(@thanks)
     render json: {
       office: @office,
       officeImages: @office.image_url,
-      thanks: thanks,
       staffs: staffs
     }, staus: :ok
   end
@@ -30,27 +28,17 @@ class Api::Customer::OfficesController < ApplicationController
     @thanks = @office.thanks
   end
 
-  def build_thanks_hash(records)
-    array = []
-    if records.exists?
-      records.each{|record|
-        hash  = record.attributes
-        staff = add_image(record.staff)
-        hash[:staff] = staff
-        array.push(hash)
-      }
-    else
-      []
-    end
-    array
-  end
-
   def add_image_h(records)
     array = []
-    records.each{|record|
-      add_image(record)
+    records.each{|re|
+      hash = add_image(re)
+      if re.thanks.exists?
+        thanks = re.thanks
+        hash[:thanks] = thanks
+      end 
       array.push(hash)
     }
+    array
   end 
 
   def add_image(obj)

--- a/app/controllers/api/customer/offices_controller.rb
+++ b/app/controllers/api/customer/offices_controller.rb
@@ -12,7 +12,14 @@ class Api::Customer::OfficesController < ApplicationController
   end
 
   def show
-    render json: {office: @office, images: @office.image_url, staffs: @staffs}
+    staffs = add_image_h(@staffs)
+    thanks = build_thanks_hash(@thanks)
+    render json: {
+      office: @office,
+      officeImages: @office.image_url,
+      thanks: thanks,
+      staffs: staffs
+    }, staus: :ok
   end
 
   private
@@ -20,6 +27,40 @@ class Api::Customer::OfficesController < ApplicationController
   def set_office
     @office = Office.find(params[:id])
     @staffs = @office.staffs
+    @thanks = @office.thanks
+  end
+
+  def build_thanks_hash(records)
+    array = []
+    if records.exists?
+      records.each{|record|
+        hash  = record.attributes
+        staff = add_image(record.staff)
+        hash[:staff] = staff
+        array.push(hash)
+      }
+    else
+      []
+    end
+    array
+  end
+
+  def add_image_h(records)
+    array = []
+    records.each{|record|
+      add_image(record)
+      array.push(hash)
+    }
+  end 
+
+  def add_image(obj)
+    hash = obj.attributes
+    hash[:image] = nil
+    if obj.image.attached?
+      image = obj.image_url
+      hash[:image] = image 
+    end
+    hash
   end
 
   def search_office_from_params


### PR DESCRIPTION
## やったこと

1. スタッフ紹介ページに対応できるように、jsonを目的のものになるように修正

## やらないこと
- テスト書かない

## できるようになること（ユーザ目線）

- スタッフ紹介ページ使用できる、jsonを返すように設定

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」で OK）

## 動作確認
テストが問題ないか確認(コンテナ内で)
```ruby
bundle exec rspec spec/requests/api/
```
- 動作確認はフロントのプルリクと一緒に行う
https://github.com/koki-takishita/home-care-navi-front/pull/183