### PR TITLE
ブックマーク登録 解除機能実装

### DIFF
--- a/app/controllers/api/customer/bookmarks_controller.rb
+++ b/app/controllers/api/customer/bookmarks_controller.rb
@@ -6,7 +6,7 @@ class Api::Customer::BookmarksController < ApplicationController
     if user_signed_in?
       bookmark = Bookmark.where(office_id: params[:office_id], user_id: current_customer.id)
     else
-      bookmark = null
+      return
     end
     render json: { bookmark: bookmark }
   end

--- a/app/controllers/api/customer/bookmarks_controller.rb
+++ b/app/controllers/api/customer/bookmarks_controller.rb
@@ -1,2 +1,53 @@
 class Api::Customer::BookmarksController < ApplicationController
+  before_action :authenticate_customer!
+  before_action :set_bookmark, only: [:destroy]
+
+  def index
+    if user_signed_in?
+      bookmark = Bookmark.where(office_id: params[:office_id], user_id: current_customer.id)
+    else
+      bookmark = null
+    end
+    render json: { bookmark: bookmark }
+  end
+
+  def create
+    customer = current_customer
+    bookmark = customer.bookmarks.build(bookmark_params)
+    if(bookmark.valid?)
+      bookmark.save!
+      render json: {
+        message: 'ブックマーク登録に成功しました'
+      }, status: :ok
+    else
+      render json: {
+        message: 'ブックマーク登録に失敗しました',
+        errors: bookmark.errors.full_messages
+      }, status: 403
+    end
+  end
+
+  def destroy
+    if @bookmark.valid?
+      @bookmark.destroy
+      render json: {
+        message: 'ブックマーク解除に成功しました'
+      }, status: :ok
+    else
+      render json: {
+        message: 'ブックマーク解除に失敗しました',
+        errors: @bookmark.errors.full_messages
+      }, status: 403
+    end
+  end
+
+  private
+
+  def bookmark_params
+    params.permit(:office_id)
+  end
+
+  def set_bookmark
+    @bookmark = current_customer.bookmarks.find(params[:id])
+  end
 end

--- a/app/controllers/api/customer/bookmarks_controller.rb
+++ b/app/controllers/api/customer/bookmarks_controller.rb
@@ -3,11 +3,7 @@ class Api::Customer::BookmarksController < ApplicationController
   before_action :set_bookmark, only: [:destroy]
 
   def index
-    if user_signed_in?
-      bookmark = Bookmark.where(office_id: params[:office_id], user_id: current_customer.id)
-    else
-      return
-    end
+    bookmark = Bookmark.where(office_id: params[:office_id], user_id: current_customer.id)
     render json: { bookmark: bookmark }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,8 @@ Rails.application.routes.draw do
     scope module: :customer do
       resources :offices, only: [:index, :show] do
         resources :thanks, only: [:create], controller: 'thanks'
-        #resources :appointments, controller: 'offices/appointments', only: [:create]
         resources :appointments, only: [:create]
+        resources :bookmarks, only: [:create, :destroy, :index]
       end
     end
   end

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bookmark do
+    association :office
+    association :user, factory: :customer
+  end
+end

--- a/spec/requests/api/customer/bookmarks_spec.rb
+++ b/spec/requests/api/customer/bookmarks_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::Customer::Bookmarks", type: :request do
     context 'カスタマー' do
       it "ブックマークを登録できる" do
 	    	login(@customer)
-	    	auth_params = get_auth_params_from_login_response_headers(response)
+        auth_params = get_auth_params_from_login_response_headers(response)
 
           post api_office_bookmarks_path(@bookmark.office_id),
           params: {
@@ -38,8 +38,8 @@ RSpec.describe "Api::Customer::Bookmarks", type: :request do
 
     context 'ケアマネ' do
       it "ブックマークを登録できない" do
-	    	login(@specialist)
-	    	auth_params = get_auth_params_from_login_response_headers(response)
+        login(@specialist)
+        auth_params = get_auth_params_from_login_response_headers(response)
 
         post api_office_bookmarks_path(@bookmark.office_id),
           params: {

--- a/spec/requests/api/customer/bookmarks_spec.rb
+++ b/spec/requests/api/customer/bookmarks_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe "Api::Customer::Bookmarks", type: :request do
   context 'ログインしていない' do
     it 'ブックマークを登録できない' do
       post api_office_bookmarks_path(@bookmark.office_id),
-          params: {
-            office_id: @bookmark.office_id,
-            user_id: @customer.id
-          }
+        params: {
+          office_id: @bookmark.office_id,
+          user_id: @customer.id
+        }
 
-          getBookmark = Customer.first.bookmarks
-          expect(getBookmark.count).to eq(0)
+        getBookmark = Customer.first.bookmarks
+        expect(getBookmark.count).to eq(0)
     end
   end
 

--- a/spec/requests/api/customer/bookmarks_spec.rb
+++ b/spec/requests/api/customer/bookmarks_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Api::Customer::Bookmarks", type: :request do
   context 'ログイン済み' do
     context 'カスタマー' do
       it "ブックマークを登録できる" do
-	    	login(@customer)
+        login(@customer)
         auth_params = get_auth_params_from_login_response_headers(response)
 
           post api_office_bookmarks_path(@bookmark.office_id),
@@ -67,12 +67,12 @@ RSpec.describe "Api::Customer::Bookmarks", type: :request do
     end
   end
 
-	def login(user)
+  def login(user)
     post api_login_path,
     params: { email: user.email, password: 'password' }
     .to_json,
     headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
-	end
+  end
 
   def get_auth_params_from_login_response_headers(response)
     client = response.headers['client']

--- a/spec/requests/api/customer/bookmarks_spec.rb
+++ b/spec/requests/api/customer/bookmarks_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+include ActionController::RespondWith
+
+RSpec.describe "Api::Customer::Bookmarks", type: :request do
+
+  before(:each) do
+    customer = build(:customer)
+    customer.skip_confirmation!
+    customer.save
+    @customer = Customer.find_by_id(customer.id)
+    @office = create(:office)
+    @bookmark  = build(:bookmark, user: @customer, office: @office)
+
+    specialist = build(:specialist)
+    specialist.skip_confirmation!
+    specialist.save
+    @specialist = Specialist.find_by_id(specialist.id)
+    @bookmark  = build(:bookmark, user: @specialist, office: @office)
+  end
+
+  context 'ログイン済み' do
+    context 'カスタマー' do
+      it "ブックマークを登録できる" do
+	    	login(@customer)
+	    	auth_params = get_auth_params_from_login_response_headers(response)
+
+          post api_office_bookmarks_path(@bookmark.office_id),
+          params: {
+            office_id: @bookmark.office_id,
+            user_id: @customer.id
+          },
+          headers: auth_params
+
+          getBookmark = Customer.first.bookmarks
+          expect(getBookmark.count).to eq(1)
+      end
+    end
+
+    context 'ケアマネ' do
+      it "ブックマークを登録できない" do
+	    	login(@specialist)
+	    	auth_params = get_auth_params_from_login_response_headers(response)
+
+        post api_office_bookmarks_path(@bookmark.office_id),
+          params: {
+            office_id: @bookmark.office_id,
+            user_id: @specialist.id
+          },
+          headers: auth_params
+
+          getBookmark = Specialist.first.bookmarks
+          expect(getBookmark.count).to eq(0)
+      end
+    end
+  end
+
+  context 'ログインしていない' do
+    it 'ブックマークを登録できない' do
+      post api_office_bookmarks_path(@bookmark.office_id),
+          params: {
+            office_id: @bookmark.office_id,
+            user_id: @customer.id
+          }
+
+          getBookmark = Customer.first.bookmarks
+          expect(getBookmark.count).to eq(0)
+    end
+  end
+
+	def login(user)
+    post api_login_path,
+    params: { email: user.email, password: 'password' }
+    .to_json,
+    headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+	end
+
+  def get_auth_params_from_login_response_headers(response)
+    client = response.headers['client']
+    token = response.headers['access-token']
+    expiry = response.headers['expiry']
+    token_type = response.headers['token-type']
+    uid = response.headers['uid']
+
+    auth_params = {
+      'access-token' => token,
+      'client' => client,
+      'uid' => uid,
+      'expiry' => expiry,
+      'token-type' => token_type
+    }
+    auth_params
+  end
+end


### PR DESCRIPTION
## やったこと

- ブックマーク登録 解除機能実装
- ブックマークのrequest spec作成

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/bookmark-create-destroy
```
### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/submit-destroy-bookmark
```

### 動作確認 Loom 手順

1. Docker内に入る
```ruby
docker-compose exec web bash
```
2. テストを実行する
```ruby
bundle exec rspec spec/requests/api/customer/bookmarks_spec.rb --format documentation
```
実行結果
```ruby
Api::Customer::Bookmarks
  ログイン済み
    カスタマー
      ブックマークを登録できる
    ケアマネ
      ブックマークを登録できない
  ログインしていない
    ブックマークを登録できない

Finished in 1.06 seconds (files took 4.02 seconds to load)
3 examples, 0 failures
```
3. すべてのテストを実行する
```ruby
bundle exec rspec spec/requests/
```
実行結果
```ruby
Finished in 2.11 seconds (files took 3.86 seconds to load)
14 examples, 0 failures
```
4. こちらのプルリクの確認をお願いします
https://github.com/koki-takishita/home-care-navi-front/pull/186

### 確認書類

[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)

## その他

- **api/customer/bookmarks_controller.rb**のindexアクションは、事業所詳細画面でブックマーク登録してるか判定するために実装しています。そのため、ブックマーク一覧画面ではこのアクションを使いません。
