### PR TITLE
ブックマークコントローラ indexアクション修正

### DIFF
--- a/app/controllers/api/customer/bookmarks_controller.rb
+++ b/app/controllers/api/customer/bookmarks_controller.rb
@@ -1,9 +1,13 @@
 class Api::Customer::BookmarksController < ApplicationController
-  before_action :authenticate_customer!
+  before_action :authenticate_customer!, only: [:create, :destroy]
   before_action :set_bookmark, only: [:destroy]
 
   def index
-    bookmark = Bookmark.where(office_id: params[:office_id], user_id: current_customer.id)
+    if customer_signed_in?
+      bookmark = Bookmark.where(office_id: params[:office_id], user_id: current_customer.id)
+    else
+      return
+    end
     render json: { bookmark: bookmark }
   end
 


### PR DESCRIPTION
## やったこと

- フロントで、ブックマークした事業所の詳細ページにアクセスしたときに、未ログイン状態だとエラーのフラッシュメッセージが出る不具合修正

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/bookmark-create-destroy
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/bookmark-create-destroy
```
```

### 動作確認 Loom 手順

- 事業所詳細画面にアクセスする
- ブックマークする
- ログアウトする
- ブックマークした事業所の詳細ページへアクセスする
- フラッシュメッセージが出てなければOK
