### PR TITLE
ログインモジュール化

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/api/customer/thanks_spec.rb
+++ b/spec/requests/api/customer/thanks_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "Api::Customer::Thanks", type: :request do
-  include LoginSupport
 
   before(:each) do
     customer = build(:customer)

--- a/spec/requests/api/customer/thanks_spec.rb
+++ b/spec/requests/api/customer/thanks_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include ActionController::RespondWith
 
 RSpec.describe "Api::Customer::Thanks", type: :request do
   include LoginSupport

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,3 +1,5 @@
+include ActionController::RespondWith
+
 module LoginSupport
 
 	def login(user)

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -2,13 +2,13 @@ include ActionController::RespondWith
 
 module LoginSupport
 
-	def login(user)
+  def login(user)
     post api_login_path,
     params: { email: user.email, password: 'password' }
     .to_json,
     headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
-  	return get_auth_params_from_login_response_headers(response)
-	end
+    return get_auth_params_from_login_response_headers(response)
+  end
 
   def get_auth_params_from_login_response_headers(response)
     client = response.headers['client']
@@ -26,7 +26,6 @@ module LoginSupport
     }
     auth_params
   end
-
 end
 
 RSpec.configure do |config|

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,32 @@
+module LoginSupport
+
+	def login(user)
+    post api_login_path,
+    params: { email: user.email, password: 'password' }
+    .to_json,
+    headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+  	return get_auth_params_from_login_response_headers(response)
+	end
+
+  def get_auth_params_from_login_response_headers(response)
+    client = response.headers['client']
+    token = response.headers['access-token']
+    expiry = response.headers['expiry']
+    token_type = response.headers['token-type']
+    uid = response.headers['uid']
+
+    auth_params = {
+      'access-token' => token,
+      'client' => client,
+      'uid' => uid,
+      'expiry' => expiry,
+      'token-type' => token_type
+    }
+    auth_params
+  end
+
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end


### PR DESCRIPTION
## やったこと

- login処理をmodule化した

## やらないこと

- これまで直うちだったのもを直すこと

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/create-login-module
```

### 動作確認
- テストがパスすること
```ruby
docker-compose exec web rspec spec/requests --format documentation
```
- 実行結果が下記のようになること
```ruby
Api::Customer::Appointments
  ログイン済み
    カスタマー
      予約を作成できる
    ケアマネ
      予約を作成できない
  ログインしていない
    予約を作成できない

Api::Customer::Bookmarks
  ログイン済み
    カスタマー
      ブックマークを登録できる
    ケアマネ
      ブックマークを登録できない
  ログインしていない
    ブックマークを登録できない

Api::Customer::Thanks
  ログイン済み
    カスタマー
      お礼を作成できる
    ケアマネ
      お礼を作成できない
  ログインしていない
    お礼を作成できない

Api::Specialists::Offices
  ログイン済み
    スペシャリスト
      事業所を登録できる
    カスタマー
      事業所を登録できない
    ログインしていない
      事業所を登録できない

Api::Specialists::Staffs
  ログイン済み
    スペシャリスト
      スタッフを登録できる
    ログインしていない
      スタッフを登録できない

Finished in 2.46 seconds (files took 3.67 seconds to load)
14 examples, 0 failures
```

### 移行ガイド
- `requests/***/***_spec.rb` のinclude部分いらないので消す 
```ruby
require 'rails_helper
include ActionController::RespondWith # これ消す
```
- login処理 
```ruby
# userの部分はログインしたいユーザーのインスタンス
# loginメソッドはheaderの情報が返ってくる、それを適当な変数に入れてリクエストする時に使う
auth_params = login(user)
```
- loginのメソッド部分を共通化したのでこちらはいらなくなる
```ruby
  def login(user)
    post api_login_path,
    params: { email: user.email, password: 'password' }
    .to_json,
    headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
  end

  def get_auth_params_from_login_response_headers(response)
    client = response.headers['client']
    token = response.headers['access-token']
    expiry = response.headers['expiry']
    token_type = response.headers['token-type']
    uid = response.headers['uid']

    auth_params = {
      'access-token' => token,
      'client' => client,
      'uid' => uid,
      'expiry' => expiry,
      'token-type' => token_type
    }
    auth_params
  end
```

## 参考になったサイト
[RSpec表示](https://shinkufencer.hateblo.jp/entry/2019/01/21/233000)
[RSpec教材](https://leanpub.com/everydayrailsrspec-jp)