### PR TITLE
閲覧履歴のindex create updateアクション実装

### DIFF
--- a/app/controllers/api/customer/histories_controller.rb
+++ b/app/controllers/api/customer/histories_controller.rb
@@ -32,7 +32,7 @@ class Api::Customer::HistoriesController < Api::Customer::OfficesController
   def update
     if @history.valid?
       # rubocop:disable Rails::SkipsModelValidations
-      # update_atのみ更新
+      # updated_atのみ更新
       @history.touch
       # rubocop:enable Rails::SkipsModelValidations
       render json: {

--- a/app/controllers/api/customer/histories_controller.rb
+++ b/app/controllers/api/customer/histories_controller.rb
@@ -1,2 +1,81 @@
-class Api::Customer::HistoriesController < ApplicationController
+class Api::Customer::HistoriesController < Api::Customer::OfficesController
+  before_action :authenticate_customer!, only: [:index, :create, :update]
+  before_action :set_customer, only: [:index, :create, :update]
+  before_action :set_history, only: [:update]
+
+  def index
+    histories = @customer.histories.order(updated_at: :desc).limit(10)
+    offices = get_office_from_histories(histories)
+    result = if(offices.count.zero?)
+               []
+             else
+               build_json(offices)
+             end
+    render json: result
+  end
+
+  def create
+    history = @customer.histories.build(history_params)
+    if history.valid?
+      history.save!
+      render json: {
+        message: '閲覧データの登録に成功しました'
+      }, status: :ok
+    else
+      render json: {
+        message: '閲覧データの登録に失敗しました',
+        errors: bookmark.errors.full_messages
+      }, status: :forbidden
+    end
+  end
+
+  def update
+    if @history.valid?
+      # updated_atのみ更新
+      @history.touch
+      render json: {
+        message: '閲覧データを更新しました',
+      }, status: :ok
+    else
+      render json: {
+        message: '更新に失敗しました',
+        errors: @history.errors.full_messages
+      }, status: :forbidden
+    end
+  end
+
+  def history_params
+    params.permit(:office_id)
+  end
+
+  def set_history
+    @history = @customer.histories.find(params[:id])
+  end
+
+  def set_customer
+    @customer = current_customer
+  end
+
+  def get_office_from_histories(histories)
+    offices_id = []
+    histories.each_with_index.map{|history|
+      offices_id.push(history.office_id)
+    }
+    offices = Office.find(offices_id)
+    offices
+  end
+
+  def build_json(offices)
+    result = offices.each_with_index.map{|office|
+     thank       = build_json_from_thank_table_attributes(office)
+     detail      = build_json_from_detail_table_attributes(office)
+     staff_count = build_json_from_staff_table_count_json(office)
+     bookmark    = build_json_from_bookmark_table(office)
+     image       = build_json_image(office)
+     office      = office.attributes
+
+     office.merge(thank, detail, image, staff_count, bookmark)
+    }
+    result
+  end
 end

--- a/app/controllers/api/customer/offices_controller.rb
+++ b/app/controllers/api/customer/offices_controller.rb
@@ -17,7 +17,8 @@ class Api::Customer::OfficesController < ApplicationController
       office: @office,
       officeImages: @office.image_url,
       staffs: staffs,
-			bookmark: @bookmark
+			bookmark: @bookmark,
+      history: @history
     }, staus: :ok
   end
 
@@ -28,11 +29,13 @@ class Api::Customer::OfficesController < ApplicationController
     @staffs = @office.staffs.select('staffs.*', 'count(thanks.id) AS thanks')
                      .left_joins(:thanks)
                      .group("staffs.id").order('thanks DESC')
-  @bookmark = if customer_signed_in?
-                current_customer.bookmarks.where(office_id: @office.id).first
-              else
-                nil
-              end
+    if customer_signed_in?
+      @bookmark = current_customer.bookmarks.where(office_id: @office.id).first
+      @history = current_customer.histories.where(office_id: @office.id).first
+    else
+       @bookmark = nil
+       @history  = nil
+    end
   end
 
   def add_image_h(records)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,11 +17,13 @@ Rails.application.routes.draw do
     resources :contacts, only: [:create]
     get '/appointments', to: 'customer/appointments#index'
 		get '/bookmarks', to: 'customer/bookmarks#index'
+    get '/histories', to: 'customer/histories#index'
     scope module: :customer do
       resources :offices, only: [:index, :show] do
         resources :thanks, only: [:create], controller: 'thanks'
         resources :appointments, only: [:create]
         resources :bookmarks, only: [:create, :destroy]
+        resources :histories, only: [:create, :update]
       end
       resources :thanks, only: [:index, :show, :update, :destroy]
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,6 +133,31 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_023101) do
     t.index ["user_id"], name: "index_offices_on_user_id"
   end
 
+  create_table "specialists", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_specialists_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_specialists_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_specialists_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_specialists_on_uid_and_provider", unique: true
+  end
+
   create_table "staffs", force: :cascade do |t|
     t.string "name"
     t.string "kana"
@@ -193,7 +218,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_023101) do
   add_foreign_key "bookmarks", "users"
   add_foreign_key "care_recipients", "offices"
   add_foreign_key "care_recipients", "staffs"
-  add_foreign_key "image_comments", "office_details"
   add_foreign_key "histories", "offices"
   add_foreign_key "histories", "users"
   add_foreign_key "office_details", "offices"


### PR DESCRIPTION
## やったこと

- 閲覧履歴のindex create updateアクション実装

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/create-history-index-create-update
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/request-create-update-history 

```

### 動作確認 Loom 手順
- こちらのプルリクを確認お願いします
https://github.com/koki-takishita/home-care-navi-front/pull/227

## 参考になったサイト
- [Railsでモデルのupdate_atのみを更新したい場合](https://qiita.com/ko30005/items/5d07c94fcfdf3bb75ff0)