### PR TITLE
ケアマネ側お礼コントローラ修正

### DIFF
--- a/app/controllers/api/specialists/thanks_controller.rb
+++ b/app/controllers/api/specialists/thanks_controller.rb
@@ -44,7 +44,7 @@ class Api::Specialists::ThanksController < ApplicationController
     # お礼の全件の数
     thank_list_total = thank_list.count
     render json: {
-      thanks: thanks.as_json(include: [:office]),
+      thanks: thanks,
       thank_total: thank_list_total
     }
   end

--- a/app/controllers/api/specialists/thanks_controller.rb
+++ b/app/controllers/api/specialists/thanks_controller.rb
@@ -44,7 +44,7 @@ class Api::Specialists::ThanksController < ApplicationController
     # お礼の全件の数
     thank_list_total = thank_list.count
     render json: {
-      thanks: thanks.as_json(include: [:staff, :office]),
+      thanks: thanks.as_json(include: [:office]),
       thank_total: thank_list_total
     }
   end

--- a/app/controllers/api/specialists/thanks_controller.rb
+++ b/app/controllers/api/specialists/thanks_controller.rb
@@ -1,40 +1,6 @@
 class Api::Specialists::ThanksController < ApplicationController
   before_action :authenticate_specialist!
 
-  # {
-  #   'thanks': [
-  #     {
-  #       "id": 50627,
-  # 	  . thanksカラムすべて
-  # 	  .
-  #     "staff": {
-  #       "id": 22083,
-  #       .staffsのカラムすべてk
-  # 	  .
-  #     },
-  #     "office": {
-  #       "id": 22083,
-  #       .officeのカラムすべて
-  # 	  .
-  #     }
-  #   },
-  #   {
-  #     "id": 50627,
-  #     . thanksカラムすべて
-  #     .
-  #     "staff": {
-  #       "id": 22083,
-  # 	.staffsのカラムすべてk
-  # 	.
-  #     },
-  #     "office": {
-  #       "id": 22083,
-  # 	.officeのカラムすべて
-  # 	.
-  # 	}
-  #   }],
-  #   "thank_total": 5
-  # }
   def index
     office_id = current_specialist.office.id
     # office_idに紐づくお礼のリストを、update_atの大きい順に取得

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,7 +193,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_023101) do
   add_foreign_key "bookmarks", "users"
   add_foreign_key "care_recipients", "offices"
   add_foreign_key "care_recipients", "staffs"
-  add_foreign_key "image_comments", "office_details"
   add_foreign_key "histories", "offices"
   add_foreign_key "histories", "users"
   add_foreign_key "office_details", "offices"

--- a/db/seeds/dummy_thanks.seeds.rb
+++ b/db/seeds/dummy_thanks.seeds.rb
@@ -5,7 +5,7 @@ def create_thanks(count: 5, office: nil)
   customers = User.customer
   unless(customers.count > 4)
     e = <<-TEXT
-    customerの数が足りません 
+    customerの数が足りません
     最後まで実行したい場合1か2の指示に従ってください。
     1. rails db:seed:dummy_customer
     2. customerを5人以上作成してください
@@ -29,6 +29,8 @@ def create_thanks(count: 5, office: nil)
 
   count.times{|n|
     customers[n].thanks.create!(
+      name: "利用者#{n}",
+      age: rand(60..120),
       comments: "#{staffs[n].name}さんは素晴らしいケアマネージャーです。",
       office_id: office.id,
       staff_id:  staffs[n].id
@@ -40,7 +42,7 @@ def set_progressbar(total: nil)
   @progressbar = ProgressBar.create(:format => '%a |%b>>%i| %p%% %t',
                                    :starting_at => 0,
                                    :total => total,
-                                   :length => 80) 
+                                   :length => 80)
 end
 
 def create_customer_thanks


### PR DESCRIPTION
## やったこと

- ケアマネ側でお礼データ一覧を返すときに、紐付いてるオフィスとスタッフも取得していたため、仕様変更に伴い紐付けを解除
- お礼seedで名前と年齢も作成するように修正
- コミット時にテスト通らなかったためdb/schema修正

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/specialist-thanks-list
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/specialist-thanks-list
```

### 動作確認 Loom 手順

- フロントのプルリクを確認する
https://github.com/koki-takishita/home-care-navi-front/pull/229
- お礼が1件もなければお礼を作成する
- 現状のseedファイルだと1オフィス5件しか作れないので、ページネーションの動作確認のため一時的にカスタマイズする
```ruby
# countを20以上にする
def create_thanks(count: 20, office: nil)
.
.
.
end
.
.
.
# 1人のケアマネが持つオフィスにたくさんのお礼が寄せられる
def create_customer_thanks
  office = Specialist.first.office
  create_thanks(office: office)
end
```
```ruby
docker-compose exec web rails db:seed:dummy_thanks
```

## 参考になったサイト

なし

## コマンド一覧

- build

```ruby
docker-compose build
```

- コンテナリスタート

```ruby
docker-compose restart
```

- コンテナ入る

```ruby
docker-compose exec web bash
```

- コンソール入る

```ruby
rails c
```