### PR TITLE
閲覧履歴モデルテスト作成

### DIFF
--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :history do
+    association :office
+    association :user, factory: :customer
+  end
+end

--- a/spec/models/history_spec.rb
+++ b/spec/models/history_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Historyモデルのテスト', type: :model do
+  describe 'アソシエーションのテスト' do
+    context 'Userモデルとの関係' do
+      it 'N:1となっている' do
+        expect(History.reflect_on_association(:user).macro).to eq :belongs_to
+      end
+    end
+
+    context 'Officeモデルとの関係' do
+      it 'N:1となっている' do
+        expect(History.reflect_on_association(:office).macro).to eq :belongs_to
+      end
+    end
+  end
+
+  describe 'バリデーションのテスト' do
+    it 'ユーザーidと事業所idがある場合、有効である' do
+      history = build(:history)
+      expect(history).to be_valid
+    end
+
+    it 'ユーザーidがない場合、無効である' do
+      history = build(:history, user_id: nil)
+      history.valid?
+      expect(history.errors[:user]).to include('を入力してください')
+    end
+
+    it '事業所idがない場合、無効である' do
+      history = build(:history, office_id: nil)
+      history.valid?
+      expect(history.errors[:office]).to include('を入力してください')
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- 閲覧履歴のモデルテスト作成

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/create-history-model-test
```

### 動作確認 Loom 手順

- テストを実行する

```ruby
docker-compose exec web bundle exec rspec spec/models/history_spec.rb --format documentation
```
実行結果
```ruby
Historyモデルのテスト
  アソシエーションのテスト
    Userモデルとの関係
      N:1となっている
    Officeモデルとの関係
      N:1となっている
  バリデーションのテスト
    ユーザーidと事業所idがある場合、有効である
    ユーザーidがない場合、無効である
    事業所idがない場合、無効である

Finished in 1.26 seconds (files took 6.62 seconds to load)
5 examples, 0 failures
```
### 参考になったサイト
- [【rspec】Railsモデルテストの基本](https://qiita.com/prkrsign890/items/1b7b4af1e6d102625562)
- [【Ruby on Rails】RSpecでのモデルテスト](https://qiita.com/japwork/items/c6f58bae5e0b222e1eb0)