### PR TITLE
閲覧履歴のリクエストスペック作成

### DIFF
--- a/spec/requests/api/customer/histories_spec.rb
+++ b/spec/requests/api/customer/histories_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Api::Customer::Bookmarks', type: :request do
+RSpec.describe 'Api::Customer::Histories', type: :request do
   before do
     customer = build(:customer)
     customer.skip_confirmation!
@@ -22,10 +22,10 @@ RSpec.describe 'Api::Customer::Bookmarks', type: :request do
       let(:history) { create(:history, user: @customer) }
 
       it '閲覧データを登録できる' do
-        post api_office_histories_path(@history.office.id),
+        post api_office_histories_path(@history.office_id),
              params: {
                user_id: @customer.id,
-               office_id: @history.office.id
+               office_id: @history.office_id
              },
              headers: auth_params
 
@@ -49,10 +49,10 @@ RSpec.describe 'Api::Customer::Bookmarks', type: :request do
     context 'ケアマネ' do
       it '閲覧データを登録できない' do
         auth_params = login(@specialist)
-        post api_office_histories_path(@history.office.id),
+        post api_office_histories_path(@history2.office_id),
              params: {
                user_id: @specialist.id,
-               office_id: @history.office.id
+               office_id: @history2.office_id
              },
              headers: auth_params
 
@@ -60,6 +60,22 @@ RSpec.describe 'Api::Customer::Bookmarks', type: :request do
         expect(history.count).to eq(0)
         expect(response).to have_http_status(:unauthorized)
       end
+    end
+  end
+
+  context 'ログインしていない' do
+    let(:history) { create(:history, user: @customer) }
+
+    it '閲覧データを登録できない' do
+      post api_office_histories_path(@history.office_id),
+           params: {
+             user_id: @customer.id,
+             office_id: @history.office_id
+           }
+
+      history = @customer.histories
+      expect(history.count).to eq(0)
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 end

--- a/spec/requests/api/customer/histories_spec.rb
+++ b/spec/requests/api/customer/histories_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Customer::Bookmarks', type: :request do
+  before do
+    customer = build(:customer)
+    customer.skip_confirmation!
+    customer.save
+    @customer = Customer.find_by(id: customer.id)
+    @office = create(:office)
+    @history  = build(:history, user: @customer, office: @office)
+
+    specialist = build(:specialist)
+    specialist.skip_confirmation!
+    specialist.save
+    @specialist = Specialist.find_by(id: specialist.id)
+    @history2 = build(:history, user: @specialist, office: @office)
+  end
+
+  context 'ログイン済み' do
+    context 'カスタマー' do
+      let(:auth_params) { login(@customer) }
+      let(:history) { create(:history, user: @customer) }
+
+      it '閲覧データを登録できる' do
+        post api_office_histories_path(@history.office.id),
+             params: {
+               user_id: @customer.id,
+               office_id: @history.office.id
+             },
+             headers: auth_params
+
+        history = @customer.histories
+        expect(history.count).to eq(1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '閲覧データを更新できる' do
+        history
+        put api_office_history_path(history.office_id, history.id),
+            params: {
+              user_id: history.user_id,
+              office_id: history.office_id
+            },
+            headers: auth_params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'ケアマネ' do
+      it '閲覧データを登録できない' do
+        auth_params = login(@specialist)
+        post api_office_histories_path(@history.office.id),
+             params: {
+               user_id: @specialist.id,
+               office_id: @history.office.id
+             },
+             headers: auth_params
+
+        history = @specialist.histories
+        expect(history.count).to eq(0)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- 閲覧履歴のリクエストスペック作成

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/request-spec-histories
```

### 動作確認 Loom 手順

- 閲覧履歴のリクエストスペックの全部のテストを実行する

```ruby
docker-compose exec web bundle exec rspec spec/requests/api/customer/histories_spec.rb --format documentation
```
実行結果
```ruby
Api::Customer::Histories
  ログイン済み
    カスタマー
      閲覧データを登録できる
      閲覧データを更新できる
    ケアマネ
      閲覧データを登録できない
  ログインしていない
    閲覧データを登録できない

Finished in 1.1 seconds (files took 3.66 seconds to load)
4 examples, 0 failures
```

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop spec/requests/api/customer/histories_spec.rb
```

