### PR TITLE
指定された電話番号に被りがないか判定するapi作成

### DIFF
--- a/app/controllers/api/check_controller.rb
+++ b/app/controllers/api/check_controller.rb
@@ -16,7 +16,7 @@ module Api
 
     def render_create_success
       render json: {
-        message: 'officeとusersテーブルに電話番号の重複していません。'
+        message: 'officeとusersテーブルに電話番号の重複はしていません。'
       }, status: :ok
     end
 

--- a/app/controllers/api/check_controller.rb
+++ b/app/controllers/api/check_controller.rb
@@ -16,7 +16,7 @@ module Api
 
     def render_create_success
       render json: {
-        message: 'officesとusersには電話番号は存在しないです。'
+        message: 'officeとusersテーブルに電話番号の重複していません。'
       }, status: :ok
     end
 

--- a/app/controllers/api/check_controller.rb
+++ b/app/controllers/api/check_controller.rb
@@ -2,16 +2,12 @@ module Api
   class CheckController < ApplicationController
 
     def check_phone_number
-      phone_number = check_params[:phone_number]
+      phone_number = params[:phone_number]
       res = !phone_number_exist?(phone_number)
       res ? render_create_success : render_error
     end
 
     private
-
-    def check_params
-      params.require(:check).permit(:phone_number)
-    end
 
     # User or Officeにphone_numerが存在するならtrue
     def phone_number_exist?(phone_number)

--- a/app/controllers/api/check_controller.rb
+++ b/app/controllers/api/check_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  class CheckController < ApplicationController
+
+    def check_phone_number
+      phone_number = check_params[:phone_number]
+      res = !phone_number_exist?(phone_number)
+      res ? render_create_success : render_error
+    end
+
+    private
+
+    def check_params
+      params.require(:check).permit(:phone_number)
+    end
+
+    # User or Officeにphone_numerが存在するならtrue
+    def phone_number_exist?(phone_number)
+      Office.phone_number_exist?(phone_number).exists? || User.phone_number_exist?(phone_number).exists?
+    end
+
+    def render_create_success
+      render json: {
+        message: 'officesとusersには電話番号は存在しないです。'
+      }, status: :ok
+    end
+
+    def render_error
+      render json: {
+        message: '登録済みの電話番号です。',
+      }, status: 403
+    end
+
+  end
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -12,6 +12,8 @@ class Office < ApplicationRecord
   has_many_attached :images
   validates :user_id, uniqueness: true, allow_nil: true
 
+  scope :phone_number_exist?, ->(phone_number) { where(phone_number: phone_number) }
+
   before_create do
     self.post_code = post_code.delete('-')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   validates :name, :phone_number, :post_code, :address, :email, presence: true
   validates :phone_number, :email, uniqueness: true
 
+  scope :phone_number_exist?, ->(phone_number) { where(phone_number: phone_number) }
   # override devise method to include additional info as opts hash
   def send_confirmation_instructions(opts = {})
     generate_confirmation_token! unless @raw_confirmation_token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :contacts, only: [:create]
-    get '/appointments', to: 'customer/appointments#index'
-		get '/bookmarks', to: 'customer/bookmarks#index'
-    get '/histories', to: 'customer/histories#index'
+    get '/appointments',       to: 'customer/appointments#index'
+    get '/bookmarks',          to: 'customer/bookmarks#index'
+    get '/histories',          to: 'customer/histories#index'
+    get '/check-phone-number', to: 'check#check_phone_number'
     scope module: :customer do
       resources :offices, only: [:index, :show] do
         resources :thanks, only: [:create], controller: 'thanks'

--- a/spec/requests/api/check_spec.rb
+++ b/spec/requests/api/check_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe "Checks", type: :request do
+  describe "GET /check-phone-number" do
+
+    before do
+      create(:customer,   phone_number: '080-0000-0000')
+      create(:specialist, phone_number: '080-0000-0001')
+      create(:office,     phone_number: '080-0000-0002')
+    end
+
+    context 'usersに登録済みの電話番号' do
+      it "403が返ってくる" do
+        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0000' } }
+        expect(response).to have_http_status(403)
+      end
+
+      it "403が返ってくる" do
+        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0001' } }
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'officesに登録済みの電話番号' do
+      it "403が返ってくる" do
+        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0002' } }
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context '未登録の電話番号' do
+      it "200が返ってくる" do
+        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0003' } }
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/requests/api/check_spec.rb
+++ b/spec/requests/api/check_spec.rb
@@ -11,26 +11,26 @@ RSpec.describe "Checks", type: :request do
 
     context 'usersに登録済みの電話番号' do
       it "403が返ってくる" do
-        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0000' } }
+        get '/api/check-phone-number', :params => { phone_number: '080-0000-0000' }
         expect(response).to have_http_status(403)
       end
 
       it "403が返ってくる" do
-        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0001' } }
+        get '/api/check-phone-number', :params => { phone_number: '080-0000-0001' }
         expect(response).to have_http_status(403)
       end
     end
 
     context 'officesに登録済みの電話番号' do
       it "403が返ってくる" do
-        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0002' } }
+        get '/api/check-phone-number', :params => { phone_number: '080-0000-0002' }
         expect(response).to have_http_status(403)
       end
     end
 
     context '未登録の電話番号' do
       it "200が返ってくる" do
-        get '/api/check-phone-number', :params => { :check => { phone_number: '080-0000-0003' } }
+        get '/api/check-phone-number', :params => { phone_number: '080-0000-0003' }
         expect(response).to have_http_status(200)
       end
     end


### PR DESCRIPTION
## やったこと

1. 電話番号が被りがないかチェックするapi作成
- 指定された電話番号がusesテーブルofficesテーブルに存在するかしないかを判定できる
2. リクエストスペック作成

## やらないこと
- rubocopのリントチェック一部
新規で追加したものでなく、過去作成したロジックでエラーが出ている模様
migrateを修正する必要があるため、今回のタスクでは見送り
```ruby

❯ docker-compose exec web bundle exec rubocop app/controllers/api/check_controller.rb app/models/office.rb app/models/user.rb config/routes.rb spec/requests/api/check_spec.rb
Inspecting 5 files
.CC..

Offenses:

app/models/office.rb:13:3: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should have a unique index on the database column.
  validates :user_id, uniqueness: true, allow_nil: true
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/user.rb:16:3: C: Rails/UniqueValidationWithoutIndex: Uniqueness validation should have a unique index on the database column.
  validates :phone_number, :email, uniqueness: true
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

5 files inspected, 2 offenses detected
```

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/phone-number-check-users-sign-up
```

### 動作確認 Loom 手順

1. データベース上で、usersテーブルに登録済みの電話番号一つ控えておく
```ruby
User.first.phone_number
```
2. データベース上で、officeテーブルに登録済みの電話番号を一つ控えておく
```ruby
Office.first.phone_number
```
3. postmanで控えた電話番号でリクエスト
  - path
  ```ruby
http://localhost:3000/api/check-phone-number
```
  - 画像
  [![Image from Gyazo](https://i.gyazo.com/19e434b9cc61e57b0b14c48dd2b0ee2e.png)](https://gyazo.com/19e434b9cc61e57b0b14c48dd2b0ee2e)
4. 403エラーが返ってくることを確認する
[![Image from Gyazo](https://i.gyazo.com/81e0dfc0bdc298970eae4f2b546dd695.png)](https://gyazo.com/81e0dfc0bdc298970eae4f2b546dd695)
5. 存在しない電話番号をリクエストする ※ 必ずデータベース上に存在しないことをを確認
```ruby
docker-compose exec web rails c
User.where(phone_number: 存在しない電話番号)
=> [ ]
Office.where(phone_number: 存在しない電話番号)
=> [ ]
```
6. 存在しない電話番号でリクエストすると200が返ってくることを確認
[![Image from Gyazo](https://i.gyazo.com/502e70b10136c50b6a23a95a94521515.png)](https://gyazo.com/502e70b10136c50b6a23a95a94521515)


### 確認書類

**URL は該当のものに変えること**  
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト

- [過度なDRYは読みやすさの敵!! リーダブルテストコードという発表をしました](https://blog.jnito.com/entry/2022/08/01/073911)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

