### PR TITLE
port 5000を許可するように設定

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:8000', 'localhost:9000'
+    origins 'localhost:8000', 'localhost:9000', 'localhost:5000'
     resource '*',
       headers: :any,
       expose: ['access-token', 'expiry', 'token-type', 'uid', 'client', 'office_data'],

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:8000', 'localhost:9000', 'localhost:5000'
+    origins 'localhost:8000', 'localhost:5000'
     resource '*',
       headers: :any,
       expose: ['access-token', 'expiry', 'token-type', 'uid', 'client', 'office_data'],


### PR DESCRIPTION
## やったこと

- port 5000からのアクセスを許可するように設定 heroku環境で実行できるようにするため ※ 参考サイト参照
- 開発環境で動くものを、本番でも動作するか確認したい時に使うもの

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/add-port-for-5000
```

### Front 側
- 最新のdevelop

### 動作確認 Loom 手順

1. フロントでコマンド実行
```ruby
yarn build && heroku local
```
2. localhost 5000にアクセスして問題なく動作するか確認する
※ リクエスト送った時にエラーでたら`cofig/`を読み込み直す必要あり
```ruby
docker-compose restart
```

### 確認書類

**URL は該当のものに変えること**  
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト

- [herokuをアプリのローカルでの実行](https://devcenter.heroku.com/ja/articles/heroku-local)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

