### PR TITLE
カスタマー側予約コントローラ　indexメソッド修正

### DIFF
--- a/app/controllers/api/customer/appointments_controller.rb
+++ b/app/controllers/api/customer/appointments_controller.rb
@@ -1,16 +1,12 @@
-class Api::Customer::AppointmentsController < Api::Customer::OfficesController
+class Api::Customer::AppointmentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_office, only: [:create]
 
   def index
     appointments = current_user.appointments.order(created_at: :desc)
-    offices = get_office_from_appointments(appointments)
-    result = if offices.size <= 0
-             []
-             else
-              build_json(offices)
-             end
-              render json: result
+    render json: { appointment: appointments.as_json(only: %i[meet_date meet_time called_status created_at], include: {
+                                                       office: { only: %i[id name phone_number], methods: %i[first_image_url staff_count] }
+                                                     }) }
   end
 
   def create
@@ -25,43 +21,12 @@ class Api::Customer::AppointmentsController < Api::Customer::OfficesController
   end
 
   private
+
     def appointment_params
       params.permit(:office_id, :meet_date, :meet_time, :name, :age, :phone_number, :comment, :user_id, :called_status)
     end
 
     def set_office
       @office = Office.find(params[:office_id])
-    end
-
-    def get_office_from_appointments(appointments)
-      offices_id = []
-      appointments.each_with_index.map{|appointment, index|
-       offices_id.push(appointment.office_id)
-       }
-      offices = Office.find(offices_id)
-    offices
-		end
-
-    def build_json(offices)
-      result = offices.each_with_index.map{|office|
-       superClass  = Api::Customer::AppointmentsController.new
-        image       = superClass.build_json_image(office)
-        staff_count = superClass.build_json_from_staff_table_count_json(office)
-        appointment = build_json_from_appointments_table_json(office)
-        office      = office.attributes
-
-        office.merge(image, staff_count, appointment)
-       }
-       result
-    end
-
-    def build_json_from_appointments_table_json(office)
-      if office.appointments.exists?
-      appointments = office.appointments.where(user_id: current_customer.id)
-      latest_office_appointment = appointments.order(created_at: :desc).first
-      { appointment: latest_office_appointment }
-      else
-       { appointment: nil}
-      end
     end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,7 +1,7 @@
 class Office < ApplicationRecord
   include FlagShihTzu
-  # TODO 存在しないuser_idが入力されたらバリテーションで引っかかるようにしたい
-  belongs_to :user, foreign_key: 'user_id', class_name: 'Specialist', optional: true
+  # TODO: 存在しないuser_idが入力されたらバリテーションで引っかかるようにしたい
+  belongs_to :user, class_name: 'Specialist', optional: true
   has_many :appointments, dependent: :destroy
   has_many :staffs, dependent: :destroy
   has_many :care_recipients, dependent: :destroy
@@ -26,11 +26,20 @@ class Office < ApplicationRecord
 
   def image_url
     helpers = Rails.application.routes.url_helpers
-    if images.blank?
-      return
-    else
-      images.map{|image| helpers.url_for(image) }
-    end
+    # 画像がなければreturn
+    return unless images.attached?
+
+    images.map { |image| helpers.url_for(image) }
+  end
+
+  def first_image_url
+    return unless images.attached?
+
+    image_url.first
+  end
+
+  def staff_count
+    staffs.count
   end
 
   has_flags(
@@ -42,5 +51,4 @@ class Office < ApplicationRecord
     6 => :friday,
     7 => :saturday
   )
-
 end


### PR DESCRIPTION
## やったこと

- 予約にオフィスが紐づくようにJSONの形を修正
  - 前回まではオフィスに予約が紐付いていた

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/fix-appointments-index
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/fix-customer-appointments-index-page
```

### 動作確認 Loom 手順

- こちらのプルリクを確認お願いします 👀 
https://github.com/koki-takishita/home-care-navi-front/pull/270

## 参考になったサイト

- [Custom JSON Rendering in Rails](https://medium.com/@tara.kelly16/custom-json-rendering-in-rails-7c68704c099e)
  - methods: [:モデルのメソッド名]の使い方を参考にした
- [ifとunlessの使い分け](https://qiita.com/raamen/items/7dc9f7b89e76cc81866b)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

