### PR TITLE
スタッフモデルテスト作成 バリデーション設定

### DIFF
--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -4,10 +4,17 @@ class Staff < ApplicationRecord
   has_one_attached :image
   has_many :thanks, dependent: :destroy
 
+  validates :name,  presence: true, length: { maximum: 30 }
+  VALID_KANA_REGEX = /\A[ぁ-んー－　 ]+\z/.freeze
+  validates :kana,  presence: true,
+                    format: { with: VALID_KANA_REGEX },
+                    length: { maximum: 30 }
+  validates :introduction,  presence: true, length: { maximum: 120 }
+
   def image_url
     helpers = Rails.application.routes.url_helpers
     if image.blank?
-      return
+      nil
     else
       helpers.url_for(image)
     end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -4,12 +4,14 @@ class Staff < ApplicationRecord
   has_one_attached :image
   has_many :thanks, dependent: :destroy
 
-  validates :name,  presence: true, length: { maximum: 30 }
+  validates :name,  presence: true,
+                    length: { maximum: 30 }
   VALID_KANA_REGEX = /\A[ぁ-んー－　 ]+\z/.freeze
   validates :kana,  presence: true,
                     format: { with: VALID_KANA_REGEX },
                     length: { maximum: 30 }
-  validates :introduction,  presence: true, length: { maximum: 120 }
+  validates :introduction,  presence: true,
+                            length: { maximum: 120 }
 
   def image_url
     helpers = Rails.application.routes.url_helpers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
       user: ユーザ
       office: 事業所
       thank: お礼
+      staff: スタッフ
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -68,6 +69,11 @@ ja:
         selected_flags: 休日の組み合わせ
         created_at: 作成日
         updated_at: 更新日
+      staff:
+        name: 名前
+        kana: ふりがな
+        introduction: 紹介文
+        office: オフィス
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。

--- a/db/migrate/20220816005014_change_columns_add_notnull_on_staffs.rb
+++ b/db/migrate/20220816005014_change_columns_add_notnull_on_staffs.rb
@@ -1,0 +1,7 @@
+class ChangeColumnsAddNotnullOnStaffs < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null(:staffs, :name, false)
+    change_column_null(:staffs, :kana, false)
+    change_column_null(:staffs, :introduction, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_01_023101) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_08_16_005014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -162,9 +161,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_023101) do
   end
 
   create_table "staffs", force: :cascade do |t|
-    t.string "name"
-    t.string "kana"
-    t.string "introduction"
+    t.string "name", null: false
+    t.string "kana", null: false
+    t.string "introduction", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "office_id"

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe 'Staffモデルのテスト', type: :model do
       expect(staff.errors[:kana]).to include('は30文字以内で入力してください')
     end
 
+    it '紹介文がない場合、無効である' do
+      staff = build(:staff, introduction: nil)
+      staff.valid?
+      expect(staff.errors[:introduction]).to include('を入力してください')
+    end
+
     it '紹介文が121文字以上の場合、無効である' do
       invalid_introduction = 'a' * 121
       staff = build(:staff, introduction: invalid_introduction)

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe 'Staffモデルのテスト', type: :model do
+  describe 'アソシエーションのテスト' do
+    context 'Officeモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Staff.reflect_on_association(:office).macro).to eq :belongs_to
+      end
+    end
+
+    context 'CareRecipientモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Staff.reflect_on_association(:care_recipients).macro).to eq :has_many
+      end
+    end
+
+    context 'Thankモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Staff.reflect_on_association(:thanks).macro).to eq :has_many
+      end
+    end
+  end
+
+  describe 'バリデーションのテスト' do
+    it '事業所id、名前、ふりがな、紹介文がある場合、有効である' do
+      staff = build(:staff)
+      # staff.valid? が true ならテストは期待通りに動いてることになる
+      expect(staff).to be_valid
+    end
+
+    it '事業所idがない場合、無効である' do
+      staff = build(:staff, office_id: nil)
+      staff.valid?
+      expect(staff.errors[:office]).to include('を入力してください')
+    end
+
+    it '名前がない場合、無効である' do
+      staff = build(:staff, name: nil)
+      staff.valid?
+      expect(staff.errors[:name]).to include('を入力してください')
+    end
+
+    it '名前が31文字以上の場合、無効である' do
+      invalid_name = 'a' * 31
+      staff = build(:staff, name: invalid_name)
+      staff.valid?
+      expect(staff.errors[:name]).to include('は30文字以内で入力してください')
+    end
+
+    it 'ふりがながない場合、無効である' do
+      staff = build(:staff, kana: nil)
+      staff.valid?
+      expect(staff.errors[:kana]).to include('を入力してください')
+    end
+
+    it 'ふりがながひらがな以外の場合、無効である' do
+      invalid_kana = ['abc', 123, '$%&@!']
+      staff = build(:staff, kana: invalid_kana.first)
+      staff.valid?
+      expect(staff.errors[:kana]).to include('は不正な値です')
+      staff = build(:staff, kana: invalid_kana.second)
+      staff.valid?
+      expect(staff.errors[:kana]).to include('は不正な値です')
+      staff = build(:staff, kana: invalid_kana.third)
+      staff.valid?
+      expect(staff.errors[:kana]).to include('は不正な値です')
+    end
+
+    it 'ふりがなが31文字以上の場合、無効である' do
+      invalid_kana = 'あ' * 31
+      staff = build(:staff, kana: invalid_kana)
+      staff.valid?
+      expect(staff.errors[:kana]).to include('は30文字以内で入力してください')
+    end
+
+    it '紹介文が121文字以上の場合、無効である' do
+      invalid_introduction = 'a' * 121
+      staff = build(:staff, introduction: invalid_introduction)
+      staff.valid?
+      expect(staff.errors[:introduction]).to include('は120文字以内で入力してください')
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- スタッフテーブルのカラムにバリデーション追加
  - 名前、ふりがな、紹介文にNot Null制約追加
- スタッフモデルにバリデーション設定
  - 名前 ... `空文字NG、30文字まで`
  - ふりがな .. `空文字NG、ひらがなの正規表現、30文字まで`
  - 紹介文 ... `空文字NG、120文字まで`
- エラーメッセージ追加
- スタッフのモデルテスト作成

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/staff-modes-test
```

### 動作確認 Loom 手順

- マイグレート実行

```ruby
docker-compose exec web bash
```
```ruby
rails db:migrate
```
```ruby
rails db:migrate:status
```
実行結果
```ruby
database: api_development

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     20220509013022  Devise token auth create users
   up     20220509083245  Add user type to users
   up     20220510060242  Create offices
   up     20220511080656  Create contacts
   up     20220516091139  Rename holiday to flags in offices
   up     20220517052740  Add selected flags to offices
   up     20220518035139  Create staffs
   up     20220518050442  Create active storage tablesactive storage
   up     20220528113639  Change staff office id to references
   up     20220531230946  Change contacts types to integer
   up     20220607114222  Create care recipients
   up     20220608034747  Rename offices column to care recipients
   up     20220608035604  Rename staffs column to care recipients
   up     20220608060022  Create thanks
   up     20220608064154  Create office details
   up     20220615050702  Create appointments
   up     20220620125926  Change appointments meet date to date
   up     20220706024811  Create bookmarks
   up     20220725090545  Add comment to office details
   up     20220801021247  Add column to thank
   up     20220801023101  Create histories
   up     20220816005014  Change columns add notnull on staffs
```
- モデルテスト実行
```ruby
rspec spec/models/staff_spec.rb --format documentation
```
実行結果
```ruby
Staffモデルのテスト
  アソシエーションのテスト
    Officeモデルとの関係
      N:1となっている
    CareRecipientモデルとの関係
      1:Nとなっている
    Thankモデルとの関係
      1:Nとなっている
  バリデーションのテスト
    事業所id、名前、ふりがな、紹介文がある場合、有効である
    事業所idがない場合、無効である
    名前がない場合、無効である
    名前が31文字以上の場合、無効である
    ふりがながない場合、無効である
    ふりがながひらがな以外の場合、無効である
    ふりがなが31文字以上の場合、無効である
    紹介文がない場合、無効である
    紹介文が121文字以上の場合、無効である

Finished in 0.7406 seconds (files took 4.05 seconds to load)
12 examples, 0 failures
```
## 参考になったサイト

- [【rspec】Railsモデルテストの基本](https://qiita.com/prkrsign890/items/1b7b4af1e6d102625562)
- [Railsドキュメント NULL制約の追加または削除](https://railsdoc.com/page/change_column_null)
- [Rubyのバリデーション用正規表現集](https://gist.github.com/nashirox/38323d5b51063ede1d41)
- [Ruby on Rails チュートリアル 第6章 ユーザーモデルを作成する 6.2.4 フォーマットを検証する](https://railstutorial.jp/chapters/modeling_users?version=6.0#sec-format_validation)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

