### PR TITLE
スタッフコントローラーでhttpステータスコード返すように設定

### DIFF
--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -21,7 +21,7 @@ class Api::Specialists::StaffsController < ApplicationController
     @staff = current_specialist.office.staffs.build(staff_params)
     if @staff.valid?
       @staff.save!
-      render status: :ok, { message: 'スタッフを登録しました' }
+      render status: :ok, json: { message: 'スタッフを登録しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
@@ -30,7 +30,7 @@ class Api::Specialists::StaffsController < ApplicationController
   def update
     if @staff.valid?
       @staff.update(staff_params)
-      render status: :ok, { message: 'スタッフを更新しました' }
+      render status: :ok, json: { message: 'スタッフを更新しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
@@ -39,7 +39,7 @@ class Api::Specialists::StaffsController < ApplicationController
   def destroy
     if @staff.valid?
       @staff.destroy
-      render status: :ok, { message: 'スタッフを削除しました' }
+      render status: :ok, json: { message: 'スタッフを削除しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end

--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -1,17 +1,16 @@
 class Api::Specialists::StaffsController < ApplicationController
-  before_action :set_staff, only: [:show, :update, :destroy]
+  before_action :set_staff, only: %i[show update destroy]
   before_action :authenticate_specialist!
 
   def index
     @order_staffs = current_specialist.office.staffs.order(updated_at: :desc)
     @data_length = @order_staffs.count
-    if params[:page].blank?
-      @staffs = @order_staffs
-      render json: { staffs: @staffs, data_length: @data_length }, methods: [:image_url]
-    else
-      @staffs = @order_staffs.limit(10).offset(params[:page].to_i * 10)
-      render json: { staffs: @staffs, data_length: @data_length }, methods: [:image_url]
-    end
+    @staffs = if params[:page].blank?
+                @order_staffs
+              else
+                @staffs = @order_staffs.limit(10).offset(params[:page].to_i * 10)
+                render json: { staffs: @staffs, data_length: @data_length }, methods: [:image_url]
+              end
   end
 
   def show
@@ -22,27 +21,27 @@ class Api::Specialists::StaffsController < ApplicationController
     @staff = current_specialist.office.staffs.build(staff_params)
     if @staff.valid?
       @staff.save!
-			render json: { status: :ok }
+      render status: :ok
     else
-      render json: { status: @staff.errors.full_messages }
+      render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
   end
 
   def update
     if @staff.valid?
       @staff.update(staff_params)
-      render json: { status: :ok }
+      render status: :ok
     else
-    render json: { status: @staff.errors.full_messages }
+      render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
   end
 
   def destroy
     if @staff.valid?
       @staff.destroy
-      render json: { status: :ok }
+      render status: :ok
     else
-      render json: { status: @staff.errors.full_messages }
+      render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
   end
 
@@ -55,4 +54,4 @@ class Api::Specialists::StaffsController < ApplicationController
     def set_staff
       @staff = current_specialist.office.staffs.find(params[:id])
     end
-  end
+end

--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -21,7 +21,7 @@ class Api::Specialists::StaffsController < ApplicationController
     @staff = current_specialist.office.staffs.build(staff_params)
     if @staff.valid?
       @staff.save!
-      render status: :ok
+      render status: :ok, { message: 'スタッフを登録しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
@@ -30,7 +30,7 @@ class Api::Specialists::StaffsController < ApplicationController
   def update
     if @staff.valid?
       @staff.update(staff_params)
-      render status: :ok
+      render status: :ok, { message: 'スタッフを更新しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end
@@ -39,7 +39,7 @@ class Api::Specialists::StaffsController < ApplicationController
   def destroy
     if @staff.valid?
       @staff.destroy
-      render status: :ok
+      render status: :ok, { message: 'スタッフを削除しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
     end

--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -28,8 +28,7 @@ class Api::Specialists::StaffsController < ApplicationController
   end
 
   def update
-    if @staff.valid?
-      @staff.update(staff_params)
+    if @staff.update(staff_params)
       render status: :ok, json: { message: 'スタッフを更新しました' }
     else
       render status: :unauthorized, json: { errors: @staff.errors.full_messages }
@@ -37,11 +36,11 @@ class Api::Specialists::StaffsController < ApplicationController
   end
 
   def destroy
-    if @staff.valid?
-      @staff.destroy
+    @staff.destroy
+    if @staff.destroyed?
       render status: :ok, json: { message: 'スタッフを削除しました' }
     else
-      render status: :unauthorized, json: { errors: @staff.errors.full_messages }
+      render status: :unauthorized, json: { errors: ['スタッフの削除に失敗しました'] }
     end
   end
 


### PR DESCRIPTION
## やったこと

- スタッフのCRUDリクエストが送られたときに、成功時と失敗時でステータスコードを返すように修正
  - 失敗時に返すエラーメッセージを、フロントでフラッシュメッセージが表示されるように修正

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/render-http_status_code-staffs_controller
```
- マージ
```ruby
git merge origin/test/staff-modes-test
```
### 動作確認 Loom 手順
- 先にこちらのプルリクを確認すること
https://github.com/koki-takishita/home-care-navi-api/pull/148
1. 空白文字を入れて登録する（半角・全角スペースのこと）
4. フラッシュメッセージが表示されていればOK（編集画面でも同様にエラーが出ることを確認する）
![image](https://user-images.githubusercontent.com/34031637/184800817-21f39ce0-ae91-4f86-9db7-27742b0cb032.png)


## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

