### PR TITLE
予約モデルテスト作成・バリデーション設定

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -2,5 +2,24 @@ class Appointment < ApplicationRecord
   belongs_to :office
   belongs_to :user
 
+  # 共通のバリデーションをまとめる
+  with_options presence: true do
+    validates :meet_date
+    validates :meet_time
+    validates :name, length: { maximum: 30 }
+    validates :age
+    validates :phone_number, format: { with: /\A\d{2,4}-\d{2,4}-\d{4}\z/ }
+    validates :comment
+    validates :called_status
+  end
+
+  validate :day_before_today
+
+  def day_before_today
+    return unless meet_date.present? && (meet_date <= Time.zone.today)
+
+    errors.add(:meet_date, 'は、明日以降の日付を入力してください')
+  end
+
   enum called_status: { need_call: 0, called: 1, cancel: 2 }
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,7 +6,13 @@ ja:
       office: 事業所
       thank: お礼
       staff: スタッフ
+      appointment: 予約
     errors:
+      models:
+        appointment:
+          attributes:
+            age:
+              in: "は数値で入力してください"
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:
@@ -74,6 +80,16 @@ ja:
         kana: ふりがな
         introduction: 紹介文
         office: オフィス
+      appointment:
+        office: オフィス
+        meet_date: 面談日
+        meet_time: 開始時間
+        name: 名前
+        age: 年齢
+        phone_number: 電話番号
+        comment: お困りごと
+        user: カスタマー
+        called_status: 連絡済みかどうかのステータス
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。
@@ -180,57 +196,57 @@ ja:
       unlocked: アカウントをロック解除しました。
   date:
     abbr_day_names:
-    - 日
-    - 月
-    - 火
-    - 水
-    - 木
-    - 金
-    - 土
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
     abbr_month_names:
-    - 
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
     day_names:
-    - 日曜日
-    - 月曜日
-    - 火曜日
-    - 水曜日
-    - 木曜日
-    - 金曜日
-    - 土曜日
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
     formats:
       default: "%Y/%m/%d"
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    - 
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
     order:
-    - :year
-    - :month
-    - :day
+      - :year
+      - :month
+      - :day
   datetime:
     distance_in_words:
       about_x_hours:
@@ -293,7 +309,7 @@ ja:
       invalid: は不正な値です
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      model_invalid: "バリデーションに失敗しました: %{errors}"
       not_a_number: は数値で入力してください
       not_an_integer: は整数で入力してください
       odd: は奇数にしてください
@@ -341,9 +357,9 @@ ja:
           quadrillion: 千兆
           thousand: 千
           trillion: 兆
-          unit: ''
+          unit: ""
       format:
-        delimiter: ''
+        delimiter: ""
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -359,11 +375,11 @@ ja:
           tb: TB
     percentage:
       format:
-        delimiter: ''
+        delimiter: ""
         format: "%n%"
     precision:
       format:
-        delimiter: ''
+        delimiter: ""
   support:
     array:
       last_word_connector: "、"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,11 +8,6 @@ ja:
       staff: スタッフ
       appointment: 予約
     errors:
-      models:
-        appointment:
-          attributes:
-            age:
-              in: "は数値で入力してください"
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:

--- a/db/migrate/20220816070850_change_columns_add_notnull_and_index_to_appointments.rb
+++ b/db/migrate/20220816070850_change_columns_add_notnull_and_index_to_appointments.rb
@@ -1,0 +1,13 @@
+class ChangeColumnsAddNotnullAndIndexToAppointments < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null(:appointments, :meet_date, false)
+    change_column_null(:appointments, :meet_time, false)
+    change_column_null(:appointments, :name, false)
+    change_column_null(:appointments, :age, false)
+    change_column_null(:appointments, :phone_number, false)
+    change_column_null(:appointments, :comment, false)
+    change_column_null(:appointments, :called_status, false)
+
+    add_index(:appointments, %i[office_id user_id], name: 'ci_appointments_01')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_16_005014) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_16_070850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,16 +44,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_005014) do
 
   create_table "appointments", force: :cascade do |t|
     t.bigint "office_id"
-    t.date "meet_date"
-    t.string "meet_time"
-    t.string "name"
-    t.string "age"
-    t.string "phone_number"
-    t.string "comment"
+    t.date "meet_date", null: false
+    t.string "meet_time", null: false
+    t.string "name", null: false
+    t.string "age", null: false
+    t.string "phone_number", null: false
+    t.string "comment", null: false
     t.bigint "user_id"
-    t.integer "called_status", default: 0
+    t.integer "called_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["office_id", "user_id"], name: "ci_appointments_01"
     t.index ["office_id"], name: "index_appointments_on_office_id"
     t.index ["user_id"], name: "index_appointments_on_user_id"
   end

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
   factory :appointment do
-    from = Time.parse("2023/01/01")
-    to = Time.parse("2023/12/31")
+    from = Time.zone.parse('2023/01/01')
+    to = Time.zone.parse('2023/12/31')
     meet_date     { rand(from..to) }
+    meet_time     { '18:00~20:00' }
     name          { Faker::Name.name }
     age           { rand(60..120) }
     phone_number  { Faker::PhoneNumber.cell_phone }

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe 'Appointmentモデルのテスト', type: :model do
+  before do
+    stub_const('VALID_PHONE_NUMBER_REGEX', /\A\d{2,4}-\d{2,4}-\d{4}\z/)
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Officeモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Appointment.reflect_on_association(:office).macro).to eq :belongs_to
+      end
+    end
+
+    context 'Userモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Appointment.reflect_on_association(:user).macro).to eq :belongs_to
+      end
+    end
+  end
+
+  describe 'バリデーションのテスト' do
+    it 'すべての項目の値が正しい場合、有効である' do
+      appointment = build(:appointment)
+      expect(appointment).to be_valid
+    end
+
+    it '面談日が今日以前の日付の場合、無効である' do
+      appointment = build(:appointment, meet_date: Time.zone.today)
+      appointment.valid?
+      expect(appointment.errors[:meet_date]).to include('は、明日以降の日付を入力してください')
+    end
+
+    it '面談時間がない場合、無効である' do
+      appointment = build(:appointment, meet_time: nil)
+      appointment.valid?
+      expect(appointment.errors[:meet_time]).to include('を入力してください')
+    end
+
+    it '名前がない場合、無効である' do
+      appointment = build(:appointment, name: nil)
+      appointment.valid?
+      expect(appointment.errors[:name]).to include('を入力してください')
+    end
+
+    it '名前が31文字以上場合、無効である' do
+      invalid_name = 'a' * 31
+      appointment = build(:appointment, name: invalid_name)
+      appointment.valid?
+      expect(appointment.errors[:name]).to include('は30文字以内で入力してください')
+    end
+
+    it '年齢がない場合、無効である' do
+      appointment = build(:appointment, age: nil)
+      appointment.valid?
+      expect(appointment.errors[:age]).to include('を入力してください')
+    end
+
+    it '電話番号がない場合、無効である' do
+      appointment = build(:appointment, phone_number: nil)
+      appointment.valid?
+      expect(appointment.errors[:phone_number]).to include('を入力してください')
+    end
+
+    it '電話番号のフォーマットが適切でない場合、無効である' do
+      # [ハイフンなし、{2~4桁}-{2~4桁}~{4桁}以外]
+      invalid_phone_numbers = %w[09012345678 1-234-5678 123-45678-901 123-456-78901]
+      invalid_phone_numbers.each do |invalid_phone_number|
+        appointment = build(:appointment, phone_number: invalid_phone_number)
+        appointment.valid?
+        expect(appointment.phone_number).not_to match(VALID_PHONE_NUMBER_REGEX)
+      end
+    end
+
+    it 'お困りごとがない場合、無効である' do
+      appointment = build(:appointment, comment: nil)
+      appointment.valid?
+      expect(appointment.errors[:comment]).to include('を入力してください')
+    end
+
+    it '連絡済みかどうかのステータスがない場合、無効である' do
+      appointment = build(:appointment, called_status: nil)
+      appointment.valid?
+      expect(appointment.errors[:called_status]).to include('を入力してください')
+    end
+  end
+end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Appointmentモデルのテスト', type: :model do
-  before do
-    stub_const('VALID_PHONE_NUMBER_REGEX', /\A\d{2,4}-\d{2,4}-\d{4}\z/)
-  end
-
   describe 'アソシエーションのテスト' do
     context 'Officeモデルとの関係' do
       it 'N:1となっている' do
@@ -68,7 +64,7 @@ RSpec.describe 'Appointmentモデルのテスト', type: :model do
       invalid_phone_numbers.each do |invalid_phone_number|
         appointment = build(:appointment, phone_number: invalid_phone_number)
         appointment.valid?
-        expect(appointment.phone_number).not_to match(VALID_PHONE_NUMBER_REGEX)
+        expect(appointment.errors[:phone_number]).to include('は不正な値です')
       end
     end
 

--- a/spec/requests/api/customer/appointments_spec.rb
+++ b/spec/requests/api/customer/appointments_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Api::Customer::Appointments", type: :request do
         post api_office_appointments_path(@appointment.office_id),
         params: {
           meet_date: @appointment.meet_date,
+          meet_time: @appointment.meet_time,
           name: @appointment.name,
           age: @appointment.name,
           phone_number: @appointment.phone_number,
@@ -50,6 +51,7 @@ RSpec.describe "Api::Customer::Appointments", type: :request do
         post api_office_appointments_path(@appointment.office_id),
         params: {
           meet_date: @appointment.meet_date,
+          meet_time: @appointment.meet_time,
           name: @appointment.name,
           age: @appointment.name,
           phone_number: @appointment.phone_number,
@@ -71,6 +73,7 @@ RSpec.describe "Api::Customer::Appointments", type: :request do
       post api_office_appointments_path(@appointment.office_id),
       params: {
         meet_date: @appointment.meet_date,
+        meet_time: @appointment.meet_time,
         name: @appointment.name,
         age: @appointment.name,
         phone_number: @appointment.phone_number,


### PR DESCRIPTION
## やったこと

- DBに予約テーブルの該当カラムにNot Null制約追加
- 予約モデルにバリデーション設定
- 予約モデルテスト作成

## やらないこと

- 年齢を60歳~120歳以外のものを弾くバリデーション設定
  - issueに上げています。やる予定はありません。
https://github.com/koki-takishita/home-care-navi-api/issues/151

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/appointment-model-test
```

### 動作確認 Loom 手順

- マイグレート

```ruby
docker-compose exec web bash
```
```ruby
rails db:migrate
```
```ruby
rails db:migrate:status
```
実行結果
```ruby
database: api_development

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     20220509013022  Devise token auth create users
   up     20220509083245  Add user type to users
   up     20220510060242  Create offices
   up     20220511080656  Create contacts
   up     20220516091139  Rename holiday to flags in offices
   up     20220517052740  Add selected flags to offices
   up     20220518035139  Create staffs
   up     20220518050442  Create active storage tablesactive storage
   up     20220528113639  Change staff office id to references
   up     20220531230946  Change contacts types to integer
   up     20220607114222  Create care recipients
   up     20220608034747  Rename offices column to care recipients
   up     20220608035604  Rename staffs column to care recipients
   up     20220608060022  Create thanks
   up     20220608064154  Create office details
   up     20220615050702  Create appointments
   up     20220620125926  Change appointments meet date to date
   up     20220706024811  Create bookmarks
   up     20220725090545  Add comment to office details
   up     20220801021247  Add column to thank
   up     20220801023101  Create histories
   up     20220816005014  Change columns add notnull on staffs
   up     20220816070850  Change columns add notnull and index to appointments
```
- テスト実行
```ruby
rspec spec/models/appointment_spec.rb --format documentation
```
実行結果
```ruby
Appointmentモデルのテスト
  アソシエーションのテスト
    Officeモデルとの関係
      N:1となっている
    Userモデルとの関係
      N:1となっている
  バリデーションのテスト
    すべての項目の値が正しい場合、有効である
    面談日が今日以前の日付の場合、無効である
    面談時間がない場合、無効である
    名前がない場合、無効である
    名前が31文字以上場合、無効である
    年齢がない場合、無効である
    電話番号がない場合、無効である
    電話番号のフォーマットが適切でない場合、無効である
    お困りごとがない場合、無効である
    連絡済みかどうかのステータスがない場合、無効である

Finished in 0.58588 seconds (files took 2.54 seconds to load)
12 examples, 0 failures
```

### 確認書類
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1171843246)

## 参考になったサイト

- [Rails 日付カラムのバリデーション設定](https://qiita.com/masaway-t10801606/items/4fbae96323609e61946a)
- [with_optionsを使って、同じバリデーションを一括りにしちゃえ！](https://qiita.com/TerToEer_sho/items/2b2c36b615d92b7dd021)
  - [Railsドキュメント 汎用的なバリデーション](https://railsdoc.com/page/validates)
- [Rubyのバリデーション用正規表現集](https://gist.github.com/nashirox/38323d5b51063ede1d41)
- [Project: RSpec Expectations 3.11 `match` matcher](https://relishapp.com/rspec/rspec-expectations/v/3-11/docs/built-in-matchers/match-matcher)
## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

