### PR TITLE
予約作成失敗時にエラーメッセージを返す

### DIFF
--- a/app/controllers/api/customer/appointments_controller.rb
+++ b/app/controllers/api/customer/appointments_controller.rb
@@ -14,9 +14,9 @@ class Api::Customer::AppointmentsController < ApplicationController
     appointment = Appointment.new(appointment_params)
     if appointment.valid?
       appointment.save!
-      render json: { status: 'success' }
+      render status: :ok, json: { message: '予約作成に成功しました' }
     else
-      render json: { status: appointment.errors.full_messages }
+      render status: :forbidden, json: { errors: appointment.errors.full_messages }
     end
   end
 

--- a/app/controllers/api/customer/appointments_controller.rb
+++ b/app/controllers/api/customer/appointments_controller.rb
@@ -16,7 +16,7 @@ class Api::Customer::AppointmentsController < ApplicationController
       appointment.save!
       render status: :ok, json: { message: '予約作成に成功しました' }
     else
-      render status: :forbidden, json: { errors: appointment.errors.full_messages }
+      render status: :unprocessable_entity, json: { errors: appointment.errors.full_messages }
     end
   end
 


### PR DESCRIPTION
## やったこと

- 予約作成失敗時にエラーメッセージを返す
  - フロント側でステータスコードと、エラーメッセージを受け取ってフラッシュメッセージに反映されるように修正

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/render_error_msg-customer_appointments_controller
```

### Front 側

- fetch and checkout

```ruby
git fetch && git checkout origin/<ここを変える>/<ここを変える>
```

### 動作確認 Loom 手順

- こちらのプルリクを確認お願いします
https://github.com/koki-takishita/home-care-navi-front/pull/284
## 参考になったサイト

- [RailsのHTTPステータスのシンボル表現](https://morizyun.github.io/ruby/rails-controller-status-code.html)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

