### PR TITLE
オフィスエリア検索リクエストスペック

### DIFF
--- a/spec/requests/api/customer/offices_spec.rb
+++ b/spec/requests/api/customer/offices_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Customer::Offices", type: :request do
-  describe "エリア検索機能" do
-
+RSpec.describe 'Api::Customer::Offices', type: :request do
+  describe 'エリア検索機能' do
     before do
       # 東京都千代田区15件分作成
-      (1..3).each {|n|
+      (1..3).each { |n|
         create(:office, address: "東京都千代田区丸の内#{n}丁目")
         create(:office, address: "東京都千代田区岩本町#{n}丁目")
         create(:office, address: "東京都千代田区一ツ橋#{n}丁目")
@@ -14,30 +13,29 @@ RSpec.describe "Api::Customer::Offices", type: :request do
       }
 
       # 北海道旭川市5件分作成
-      (1..2).each {|n|
+      (1..2).each { |n|
         create(:office, address: "北海道旭川市秋月#{n}条")
         create(:office, address: "北海道旭川市神楽岡#{n}条")
       }
-      create(:office, address: "北海道旭川市江丹別町")
+      create(:office, address: '北海道旭川市江丹別町')
 
       # 新潟県佐渡市5件分作成
-      create(:office, address: "新潟県佐渡市両津夷")
-      create(:office, address: "新潟県佐渡市金井町大字千種")
-      create(:office, address: "新潟県佐渡市秋津")
-      create(:office, address: "新潟県佐渡市相川三町目")
-      create(:office, address: "新潟県佐渡市小木町")
+      create(:office, address: '新潟県佐渡市両津夷')
+      create(:office, address: '新潟県佐渡市金井町大字千種')
+      create(:office, address: '新潟県佐渡市秋津')
+      create(:office, address: '新潟県佐渡市相川三町目')
+      create(:office, address: '新潟県佐渡市小木町')
 
       # 沖縄那覇市5件分作成
-      create(:office, address: "沖縄県那覇市垣花町")
-      create(:office, address: "沖縄県那覇市首里赤田町")
-      create(:office, address: "沖縄県那覇市住吉町")
-      create(:office, address: "沖縄県那覇市仲井真")
-      create(:office, address: "沖縄県那覇市繁多川")
+      create(:office, address: '沖縄県那覇市垣花町')
+      create(:office, address: '沖縄県那覇市首里赤田町')
+      create(:office, address: '沖縄県那覇市住吉町')
+      create(:office, address: '沖縄県那覇市仲井真')
+      create(:office, address: '沖縄県那覇市繁多川')
     end
 
     context '登録済みデータ' do
       context '東京都千代田区' do
-
         it '取得できるのは最大10件' do
           get '/api/offices', params: { prefecture: '東京都', cities: '千代田区' }
           # response.bodyがstringのため変換している
@@ -50,7 +48,6 @@ RSpec.describe "Api::Customer::Offices", type: :request do
         # page: 1 11〜20 10件分オフセット
         # page: 2 21〜30 20件分オフセット
         context 'オフセット' do
-
           it '5件取得できる' do
             get '/api/offices', params: { prefecture: '東京都', cities: '千代田区', page: 1 }
             expect(JSON.parse(response.body).count).to eq 5
@@ -60,7 +57,6 @@ RSpec.describe "Api::Customer::Offices", type: :request do
             get '/api/offices', params: { prefecture: '東京都', cities: '千代田区', page: 2 }
             expect(JSON.parse(response.body).count).to eq 0
           end
-
         end
       end
 
@@ -84,56 +80,43 @@ RSpec.describe "Api::Customer::Offices", type: :request do
           expect(JSON.parse(response.body).count).to eq 5
         end
       end
-
     end
 
     context '登録されていないデータ' do
-
       context '静岡県浜松市' do
-
         it 'ヒットしない' do
           get '/api/offices', params: { prefecture: '静岡県', cities: '浜松市' }
           expect(JSON.parse(response.body).count).to eq 0
         end
-
       end
 
       context '東京都港区' do
-
         it 'ヒットしない' do
           get '/api/offices', params: { prefecture: '東京都', cities: '港区' }
           expect(JSON.parse(response.body).count).to eq 0
         end
-
       end
 
       context '新潟県新潟市' do
-
         it 'ヒットしない' do
           get '/api/offices', params: { prefecture: '新潟県', cities: '新潟市' }
           expect(JSON.parse(response.body).count).to eq 0
         end
-
       end
 
       context '北海道札幌市' do
-
         it 'ヒットしない' do
           get '/api/offices', params: { prefecture: '北海道', cities: '札幌市' }
           expect(JSON.parse(response.body).count).to eq 0
         end
-
       end
 
       context '沖縄県石垣市' do
-
         it 'ヒットしない' do
           get '/api/offices', params: { prefecture: '沖縄県', cities: '石垣市' }
           expect(JSON.parse(response.body).count).to eq 0
         end
-
       end
-
     end
   end
 end

--- a/spec/requests/api/customer/offices_spec.rb
+++ b/spec/requests/api/customer/offices_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Customer::Offices", type: :request do
+  describe "エリア検索機能" do
+
+    before do
+      # 東京都千代田区15件分作成
+      (1..3).each {|n|
+        create(:office, address: "東京都千代田区丸の内#{n}丁目")
+        create(:office, address: "東京都千代田区岩本町#{n}丁目")
+        create(:office, address: "東京都千代田区一ツ橋#{n}丁目")
+        create(:office, address: "東京都千代田区神田神保町#{n}丁目")
+        create(:office, address: "東京都千代田区鍛冶町#{n}丁目")
+      }
+
+      # 北海道旭川市5件分作成
+      (1..2).each {|n|
+        create(:office, address: "北海道旭川市秋月#{n}条")
+        create(:office, address: "北海道旭川市神楽岡#{n}条")
+      }
+      create(:office, address: "北海道旭川市江丹別町")
+
+      # 新潟県佐渡市5件分作成
+      create(:office, address: "新潟県佐渡市両津夷")
+      create(:office, address: "新潟県佐渡市金井町大字千種")
+      create(:office, address: "新潟県佐渡市秋津")
+      create(:office, address: "新潟県佐渡市相川三町目")
+      create(:office, address: "新潟県佐渡市小木町")
+
+      # 沖縄那覇市5件分作成
+      create(:office, address: "沖縄県那覇市垣花町")
+      create(:office, address: "沖縄県那覇市首里赤田町")
+      create(:office, address: "沖縄県那覇市住吉町")
+      create(:office, address: "沖縄県那覇市仲井真")
+      create(:office, address: "沖縄県那覇市繁多川")
+    end
+
+    context '登録済みデータ' do
+      context '東京都千代田区' do
+
+        it '取得できるのは最大10件' do
+          get '/api/offices', params: { prefecture: '東京都', cities: '千代田区' }
+          # response.bodyがstringのため変換している
+          expect(JSON.parse(response.body).count).to eq 10
+        end
+
+        # pageに値を指定するとオフセットできる
+        #
+        # page: 0  0〜10 最初の10件
+        # page: 1 11〜20 10件分オフセット
+        # page: 2 21〜30 20件分オフセット
+        context 'オフセット' do
+
+          it '5件取得できる' do
+            get '/api/offices', params: { prefecture: '東京都', cities: '千代田区', page: 1 }
+            expect(JSON.parse(response.body).count).to eq 5
+          end
+
+          it 'ヒットしない' do
+            get '/api/offices', params: { prefecture: '東京都', cities: '千代田区', page: 2 }
+            expect(JSON.parse(response.body).count).to eq 0
+          end
+
+        end
+      end
+
+      context '新潟県佐渡市' do
+        it '5件取得できる' do
+          get '/api/offices', params: { prefecture: '新潟県', cities: '佐渡市' }
+          expect(JSON.parse(response.body).count).to eq 5
+        end
+      end
+
+      context '北海道旭川市' do
+        it '5件取得できる' do
+          get '/api/offices', params: { prefecture: '北海道', cities: '旭川市' }
+          expect(JSON.parse(response.body).count).to eq 5
+        end
+      end
+
+      context '沖縄県那覇市' do
+        it '5件取得できる' do
+          get '/api/offices', params: { prefecture: '沖縄県', cities: '那覇市' }
+          expect(JSON.parse(response.body).count).to eq 5
+        end
+      end
+
+    end
+
+    context '登録されていないデータ' do
+
+      context '静岡県浜松市' do
+
+        it 'ヒットしない' do
+          get '/api/offices', params: { prefecture: '静岡県', cities: '浜松市' }
+          expect(JSON.parse(response.body).count).to eq 0
+        end
+
+      end
+
+      context '東京都港区' do
+
+        it 'ヒットしない' do
+          get '/api/offices', params: { prefecture: '東京都', cities: '港区' }
+          expect(JSON.parse(response.body).count).to eq 0
+        end
+
+      end
+
+      context '新潟県新潟市' do
+
+        it 'ヒットしない' do
+          get '/api/offices', params: { prefecture: '新潟県', cities: '新潟市' }
+          expect(JSON.parse(response.body).count).to eq 0
+        end
+
+      end
+
+      context '北海道札幌市' do
+
+        it 'ヒットしない' do
+          get '/api/offices', params: { prefecture: '北海道', cities: '札幌市' }
+          expect(JSON.parse(response.body).count).to eq 0
+        end
+
+      end
+
+      context '沖縄県石垣市' do
+
+        it 'ヒットしない' do
+          get '/api/offices', params: { prefecture: '沖縄県', cities: '石垣市' }
+          expect(JSON.parse(response.body).count).to eq 0
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- オフィスエリア検索のリクエストスペック

## やらないこと

- キーワード検索 別のプルリクで扱う今回はエリア検索のみ

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/request-spec-to-office-area
```

### 動作確認 Loom 手順

- テストパスするか確認
```ruby
# 全体のテスト
bundle exec rspec --format documentation

# 今回作成したテスト
bundle exec rspec spec/requests/api/customer/offices_spec.rb --format documentation
```

### json parseをしている理由
何件取得したかを知りたかったが、`response.body`は`String`のため`count`メソッドが使えない　　
なので↓のようにJSON.parseするとhashに変換され、`count`メソッドが使えるようになる
```ruby
response.body
=> "[
"{
  /"id"/: 1,
  /"name"/: "/ケアパーク/"
  },
  {
    /"id"/: 1,
    /"name"/: "/老人介護ホーム佐渡/"
  }
  .
  .
  .
]"

JSON.parse(response.body)
=> [
  {
    id: 1
    name: 'ケアパーク'
    .
    .
  },
  {
    id: 2
    name: '老人介護ホーム佐渡'
    .
    .
  },
  .
  .
  .
]
```
[動かして確認している](https://www.loom.com/share/594db5ac814e42c5a2dece0f2f40639a)

## 参考になったサイト

- [json parse doc](https://docs.ruby-lang.org/ja/latest/method/JSON/m/parse.html)
- [rspec doc](https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

