### PR TITLE
利用者登録・編集画面でスタッフ取得できない不具合修正

### DIFF
--- a/app/controllers/api/specialists/staffs_controller.rb
+++ b/app/controllers/api/specialists/staffs_controller.rb
@@ -5,12 +5,14 @@ class Api::Specialists::StaffsController < ApplicationController
   def index
     @order_staffs = current_specialist.office.staffs.order(updated_at: :desc)
     @data_length = @order_staffs.count
-    @staffs = if params[:page].blank?
-                @order_staffs
-              else
-                @staffs = @order_staffs.limit(10).offset(params[:page].to_i * 10)
-                render json: { staffs: @staffs, data_length: @data_length }, methods: [:image_url]
-              end
+    # 利用者登録・編集画面ではparamsにpageがない
+    if params[:page].blank?
+      @staffs = @order_staffs
+      render json: { staffs: @staffs }
+    else
+      @staffs = @order_staffs.limit(10).offset(params[:page].to_i * 10)
+      render json: { staffs: @staffs, data_length: @data_length }, methods: [:image_url]
+    end
   end
 
   def show


### PR DESCRIPTION
## やったこと

- 利用者登録・編集画面でスタッフ取得できない不具合修正

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/care_recipients_staff_index
```

### 動作確認 Loom 手順

- 利用者登録画面と編集画面でスタッフ表示されてるか確認

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

