### PR TITLE
バグ改修：問い合わせ 空白登録時エラーメッセージ表示

### DIFF
--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -8,7 +8,7 @@ module Api
         render json: @contacts, status: :ok
         ContactMailer.send_message(@contacts).deliver_now
       else
-        render json: { status: @contacts.errors.full_messages }
+        render status: :unauthorized, json: { errors: @contacts.errors.full_messages }
       end
     end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -85,6 +85,11 @@ ja:
         comment: お困りごと
         user: カスタマー
         called_status: 連絡済みかどうかのステータス
+      contact:
+        name: 名前
+        email: メールアドレス
+        types: 利用者区分
+        content: お問い合わせ内容
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。


### PR DESCRIPTION
## やったこと

・空白スペースで問い合わせ入力　→　確認画面で送信押すと、エラーメッセージを画面表示
・空白スペース入力で問い合わせ完了ページまで遷移できていたため、それが防止された。

## やらないこと

- 送信ボタンPUSHでセッションストレージ破棄をしているため、
　エラー表示後に『戻る』を押しても入力していたデータはリセットされる。

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/contacts-valid-message-api
```

### 動作確認 Loom 手順

- 名前と問い合わせ内容のフォームを、空白スペースで問い合わせ入力

[確認画面にて送信ボタンPUSHし、エラーメッセージを確認](https://gyazo.com/8dd28531bc395d815db349163666d29e)

### 確認書類

**URL は該当のものに変えること**  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  


## 参考になったサイト
なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

