### PR TITLE
利用者登録　空白で登録できなくする

### DIFF
--- a/app/controllers/api/specialists/care_recipients_controller.rb
+++ b/app/controllers/api/specialists/care_recipients_controller.rb
@@ -1,12 +1,12 @@
 class Api::Specialists::CareRecipientsController < ApplicationController
   before_action :authenticate_specialist!
-  before_action :set_care_recipient, only: [:show, :update, :destroy]
+  before_action :set_care_recipient, only: %i[show update destroy]
 
   def index
     @order_care_recipients = current_specialist.office.care_recipients.order(updated_at: :desc)
     @data_length = @order_care_recipients.count
     @care_recipients = @order_care_recipients.limit(10).offset(params[:page].to_i * 10)
-    render json: { care_recipients: @care_recipients.as_json(:include => [:staff], methods: [:image_url]), data_length: @data_length}
+    render json: { care_recipients: @care_recipients.as_json(include: [:staff], methods: [:image_url]), data_length: @data_length }
   end
 
   def show
@@ -14,31 +14,20 @@ class Api::Specialists::CareRecipientsController < ApplicationController
   end
 
   def create
-    care_recipient = current_specialist.office.care_recipients.build(care_recipient_params)
-    if care_recipient.valid?
-      care_recipient.save!
-      render json: { status: :ok }
-    else
-      render json: { status: care_recipient.errors.full_messages }
-    end
-  end
-
-  def create
     @care_recipient = current_specialist.office.care_recipients.build(care_recipient_params)
     if @care_recipient.valid?
       @care_recipient.save!
-			render json: { status: :ok }
+      render json: { status: :ok }
     else
-      render json: { status: @care_recipient.errors.full_messages }
+      render status: :unprocessable_entity, json: { errors: @care_recipient.errors.full_messages }
     end
   end
 
   def update
-    if @care_recipient.valid?
-      @care_recipient.update(care_recipient_params)
+    if @care_recipient.update(care_recipient_params)
       render json: { status: 'success' }
     else
-    render json: { status: @care_recipient.errors.full_messages }
+      render status: :unauthorized, json: { errors: @care_recipient.errors.full_messages }
     end
   end
 
@@ -52,11 +41,12 @@ class Api::Specialists::CareRecipientsController < ApplicationController
   end
 
   private
-  def care_recipient_params
-    params.permit(:office_id, :name, :kana, :age, :post_code, :address, :staff_id, :family,  :image)
-  end
 
-  def set_care_recipient
-    @care_recipient = current_specialist.office.care_recipients.find(params[:id])
-  end
+    def care_recipient_params
+      params.permit(:office_id, :name, :kana, :age, :post_code, :address, :staff_id, :family, :image)
+    end
+
+    def set_care_recipient
+      @care_recipient = current_specialist.office.care_recipients.find(params[:id])
+    end
 end

--- a/app/models/care_recipient.rb
+++ b/app/models/care_recipient.rb
@@ -1,12 +1,19 @@
 class CareRecipient < ApplicationRecord
+  with_options presence: true do
+    validates :kana
+    validates :name, length: { maximum: 30 }
+    validates :family, length: { maximum: 30 }
+    validates :address
+  end
+
   belongs_to :office
   belongs_to :staff
   has_one_attached :image
-  
+
   def image_url
     helpers = Rails.application.routes.url_helpers
     if image.blank?
-      return
+      nil
     else
       helpers.url_for(image)
     end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
       thank: お礼
       staff: スタッフ
       appointment: 予約
+      care_recipient: 利用者
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -75,6 +76,12 @@ ja:
         kana: ふりがな
         introduction: 紹介文
         office: オフィス
+      care_recipient:
+        name: 名前
+        kana: ふりがな
+        address: 住所
+        family: 家族情報
+        age: 年齢
       appointment:
         office: オフィス
         meet_date: 面談日


### PR DESCRIPTION
## やったこと

- 空白バリデーション設定

## やらないこと

- フロントの空白バリデーション
### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/care_recipient_validation
```


### 動作確認 Loom 手順

- 利用者を空白でスペースで入力

```ruby
手順1.利用者の名前・かな・家族情報・住所をスペースで入力（登録と編集）
手順2.エラーメッセ時が表示される
```
[手順動画](https://www.loom.com/share/eb3eb5b8f8dd46e8bbdbc6ccc915d725)
### 確認書類

**URL は該当のものに変えること**  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  


## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

