### PR TITLE
カスタマー編集・削除 コントローラーテスト作成

### DIFF
--- a/app/controllers/api/overrides/customer/registrations_controller.rb
+++ b/app/controllers/api/overrides/customer/registrations_controller.rb
@@ -4,7 +4,7 @@ module Api
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
         before_action :configure_permitted_parameters
         before_action :set_redirect_url, only: [:update]
-      
+
         def render_create_success
           render json: {
             status: 'success',
@@ -21,19 +21,21 @@ module Api
         def password_check
           if (params[:current_password]).present?
             @user = User.find(current_user.id)
-          unless @user.valid_password?(params[:current_password])
-            render json: {
-              message: 'パスワードが違います',
-              errors: ["パスワードが違います"],
-            }, status: 401
-          end
+            if @user.valid_password?(params[:current_password])
+              render status: :ok
+            else
+              render json: {
+                 message: 'パスワードが違います',
+                  errors: ["パスワードが違います"],
+                }, status: 401
+            end
           end
         end
 
-        def update  
+        def update
           @user = User.find(current_user.id)
           if @user.update(update_params)
-             render json: { status: 'success' }
+             render status: :ok
           else
             @user.update(update_params)
             render status: 401, json: { errors: @user.errors.full_messages }
@@ -41,13 +43,13 @@ module Api
         end
 
         protected
-        
+
         def update_params
           params.permit(:phone_number, :name, :post_code, :address,:email,:password,:redirect_url)
         end
 
         def configure_permitted_parameters
-          devise_parameter_sanitizer.permit(:sign_up, keys: %i( name 
+          devise_parameter_sanitizer.permit(:sign_up, keys: %i( name
                                                                 phone_number
                                                                 post_code
                                                                 address

--- a/spec/requests/api/customer/edit_delete_spec.rb
+++ b/spec/requests/api/customer/edit_delete_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Customer', type: :request do
+  before do
+    customer = build(:customer)
+    customer.skip_confirmation!
+    customer.save
+    @customer = Customer.find_by(id: customer.id)
+  end
+
+  context 'ログイン済みカスタマー' do
+    let(:auth_params) { login(@customer, @customer.user_type) }
+
+    it 'パスワードチェックが通る' do
+      post api_users_path,
+           params: {
+             current_password: 'password'
+           },
+           headers: auth_params
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'パスワードが違うと通らない' do
+      post api_users_path,
+           params: {
+             current_password: 'password123'
+           },
+           headers: auth_params
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '自分の情報を編集できる' do
+      put '/api/customer',
+          params: {
+            name: '名前',
+            email: 'test@test.com',
+            password: 'password',
+            password_confirmation: 'password',
+            phone_number: '090-1234-5678',
+            post_code: '123-4567',
+            address: '住所',
+            redirect_url: 'http://localhost:8000/users/login'
+          },
+          headers: auth_params
+      updated_customer = Customer.find_by(id: @customer.id)
+      expect(response).to have_http_status(:ok)
+      expect(updated_customer.name).to eq('名前')
+    end
+
+    it '退会できる' do
+      delete api_users_path,
+             headers: auth_params
+      expect(response).to have_http_status(:ok)
+      expect(Customer.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- カスタマー編集・削除 コントローラーテスト作成
- パスワードチェックとユーザー情報編集時に、成功時のステータスコードを200が返ってくるように修正
  - 以前は204(No Content)が返ってきていた

## やらないこと

- 未ログインの状態で編集・退会ができないかテストすること
  - エラーが出てしまうためテストしない

`app/controllers/api/overrides/customer/registrations_controller.rb`
```ruby
# current_user.idが見つからないというエラーが出る
@user = User.find(current_user.id)
```

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/customer-edit-delete
```

### 動作確認 Loom 手順

- テスト実行

```ruby
docker-compose exec web bundle exec rspec spec/requests/api/customer/edit_delete_spec.rb --format documentation   
```
実行結果
```ruby
Api::Customer
  ログイン済みカスタマー
    パスワードチェックが通る
    パスワードが違うと通らない
    自分の情報を編集できる
    退会できる

Finished in 1.1 seconds (files took 3.91 seconds to load)
4 examples, 0 failures
```

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

