### PR TITLE
お礼同じスタッフに２回以上作成したときのエラーメッセージ変更

### DIFF
--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -5,9 +5,8 @@ class Thank < ApplicationRecord
   validates :comments, presence: true, length: { maximum: 120 }
   validates :name, length: { maximum: 30 }
   validates :name, :age, presence: true
-  validates :office_id, uniqueness: {
-    scope: [ :user_id, :staff_id ],
-      message: "に2回以上お礼は作成できません。"
-    }
+  validates :staff_id, uniqueness: { scope: [ :user_id, :office_id ],
+    message: "同じ%{attribute}にお礼を作成できるのは１回までです"
+  }
   scope :thank_list_of_office, ->(office_id) { eager_load(:staff, :office).where(office_id: office_id).order("thanks.updated_at DESC") }
 end

--- a/app/models/thank.rb
+++ b/app/models/thank.rb
@@ -5,8 +5,6 @@ class Thank < ApplicationRecord
   validates :comments, presence: true, length: { maximum: 120 }
   validates :name, length: { maximum: 30 }
   validates :name, :age, presence: true
-  validates :staff_id, uniqueness: { scope: [ :user_id, :office_id ],
-    message: "同じ%{attribute}にお礼を作成できるのは１回までです"
-  }
-  scope :thank_list_of_office, ->(office_id) { eager_load(:staff, :office).where(office_id: office_id).order("thanks.updated_at DESC") }
+  validates :staff_id, uniqueness: { scope: %i[user_id office_id] }
+  scope :thank_list_of_office, ->(office_id) { eager_load(:staff, :office).where(office_id: office_id).order('thanks.updated_at DESC') }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,6 @@ module Api
     config.active_record.default_timezone = :local
     config.api_only = true
     config.middleware.use ActionDispatch::Session::CookieStore
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,9 @@ ja:
         not_saved:
           one: "エラーが発生したため %{resource} は保存されませんでした。"
           other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+      models:
+        thank:
+          format: "%{message}"
     attributes:
       user:
         phone_number: 電話番号
@@ -51,9 +54,9 @@ ja:
         unlock_token: ロック解除用トークン
         updated_at: 更新日
       thank:
-        user: カスタマー
-        office: オフィス
-        staff: スタッフ
+        user_id: カスタマー
+        office_id: オフィス
+        staff_id: スタッフ
         comments: お礼コメント
         age: 年齢
         name: 利用者名

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,7 @@ ja:
         thank:
           format: "%{message}"
           taken: "同じ%{attribute}にお礼を作成できるのは1回までです"
+          blank: "%{attribute}を入力してください"
     attributes:
       user:
         phone_number: 電話番号

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,6 +24,7 @@ ja:
       models:
         thank:
           format: "%{message}"
+          taken: "同じ%{attribute}にお礼を作成できるのは1回までです"
     attributes:
       user:
         phone_number: 電話番号


### PR DESCRIPTION
## やったこと

- 従来のエラーメッセージでは意図が伝わらないため、エラーメッセージ変更

## やらないこと

- config/local/ja.ymlのrubocop修正
修正箇所が膨大なため、別のプルリクとして実施する

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/thank-error-msg

```

### 動作確認 Loom 手順

- こちらのプルリク手順に従う
https://github.com/koki-takishita/home-care-navi-front/pull/300

### 確認書類

**URL は該当のものに変えること**  
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト

- [バリテーション、エラーメッセージフォーマットをカスタマイズする](https://zenn.dev/machamp/articles/rails-validation-message)
- [railsガイド config-active-model-i18n-customize-full-message](https://railsguides.jp/configuring.html#config-active-model-i18n-customize-full-message)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [ ] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

