### PR TITLE
APIテスト　利用者CRUD Rspec

### DIFF
--- a/spec/factories/care_recipient.rb
+++ b/spec/factories/care_recipient.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :care_recipient do
+    name { 'テスト' }
+    kana { 'かな' }    
+    age { 100 }
+    post_code { Faker::Address.postcode } 
+    address   { 'sample address' }
+    family   { 'sample family' }
+    association :office
+    association :staff
+  end
+end

--- a/spec/factories/care_recipient.rb
+++ b/spec/factories/care_recipient.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :care_recipient do
-    name { 'テスト' }
-    kana { 'かな' }    
+    name { '田中 太郎' }
+    kana { 'たなか たろう' }    
     age { 100 }
     post_code { Faker::Address.postcode } 
     address   { 'sample address' }

--- a/spec/requests/api/specialist/care_recipients_spec.rb
+++ b/spec/requests/api/specialist/care_recipients_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::Specialists::CareRecipients', type: :request do
+  before do
+    specialist = build(:specialist)
+    specialist.skip_confirmation!
+    specialist.save
+    @specialist = Specialist.find_by(id: specialist.id)
+    @office = create(:office, user: @specialist)
+    @staff = FactoryBot.create(:staff, office: @office)
+    @sample_image = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/youngman.png'), 'image/png')
+    @care_recipient = build(:care_recipient, office: @office, staff: @staff)
+  end
+
+  context 'ログイン済み' do
+    let(:care_recipient) { create(:care_recipient, office: @office) }
+    let(:before_name) { '利用者の名前' }
+    let(:update_name) { '利用者の更新した名前' }
+
+    context 'スペシャリスト' do
+      let(:auth_params) { login(@specialist, @specialist.user_type) }
+
+      it '利用者を登録できる' do
+        post api_specialists_offices_care_recipients_path(@care_recipient.office_id),
+             params: {
+               name: @care_recipient.name,
+               kana: @care_recipient.kana,
+               post_code: @care_recipient.post_code,
+               age: @care_recipient.age,
+               address: @care_recipient.address,
+               family: @care_recipient.family,
+               image: @sample_image,
+               staff_id: @care_recipient.staff_id,
+               office_id: @care_recipient.office_id
+             },
+             headers: auth_params
+    
+
+        office = @specialist.office
+        care_recipient = office.care_recipients.first
+        expect(office.care_recipients.count).to eq(1)
+        expect(care_recipient.image_blob.blank?).to be(false)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '利用者を編集できる' do
+        care_recipient
+        put api_specialists_offices_care_recipient_path(care_recipient.id),
+            params: {
+              name: update_name
+            },
+            headers: auth_params
+
+        office = @specialist.office
+        care_recipient = office.care_recipients.first
+        expect(care_recipient.name).to eq('利用者の更新した名前')
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '利用者を削除できる' do
+        care_recipient
+        delete api_specialists_offices_care_recipient_path(care_recipient.id),
+               headers: auth_params
+        
+        office = @specialist.office
+        expect(response).to have_http_status(:ok)
+        expect(office.care_recipients.count).to eq(0)
+      end
+     end
+  end
+  context 'ログインしていない' do
+    it '利用者を登録できない' do
+      post api_specialists_offices_care_recipients_path(@care_recipient.office_id),
+      params: {
+        name: @care_recipient.name,
+        kana: @care_recipient.kana,
+        post_code: @care_recipient.post_code,
+        age: @care_recipient.age,
+        address: @care_recipient.address,
+        family: @care_recipient.family,
+        image: @sample_image,
+        staff_id: @care_recipient.staff_id,
+        office_id: @care_recipient.office_id
+      }
+      
+      office = @specialist.office
+      expect(office.care_recipients.count).to eq(0)
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/api/specialist/care_recipients_spec.rb
+++ b/spec/requests/api/specialist/care_recipients_spec.rb
@@ -42,6 +42,24 @@ RSpec.describe 'Api::Specialists::CareRecipients', type: :request do
         expect(response).to have_http_status(:ok)
       end
 
+      it '利用者の一覧を取得できる' do
+        care_recipient
+        get api_specialists_offices_care_recipients_path,
+            headers: auth_params
+
+        expect(JSON.parse(response.body)['care_recipients'].count).to eq(1)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '利用者の詳細データを取得できる' do
+        care_recipient
+        get api_specialists_offices_care_recipient_path(care_recipient.id),
+            headers: auth_params
+
+        expect([JSON.parse(response.body)].size).to eq(1)
+        expect(response).to have_http_status(:ok)
+      end
+
       it '利用者を編集できる' do
         care_recipient
         put api_specialists_offices_care_recipient_path(care_recipient.id),

--- a/spec/requests/api/specialist/care_recipients_spec.rb
+++ b/spec/requests/api/specialist/care_recipients_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Api::Specialists::CareRecipients', type: :request do
     specialist.save
     @specialist = Specialist.find_by(id: specialist.id)
     @office = create(:office, user: @specialist)
-    @staff = FactoryBot.create(:staff, office: @office)
+    @staff = create(:staff, office: @office)
     @sample_image = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/youngman.png'), 'image/png')
     @care_recipient = build(:care_recipient, office: @office, staff: @staff)
   end
@@ -34,7 +34,6 @@ RSpec.describe 'Api::Specialists::CareRecipients', type: :request do
                office_id: @care_recipient.office_id
              },
              headers: auth_params
-    
 
         office = @specialist.office
         care_recipient = office.care_recipients.first
@@ -61,28 +60,29 @@ RSpec.describe 'Api::Specialists::CareRecipients', type: :request do
         care_recipient
         delete api_specialists_offices_care_recipient_path(care_recipient.id),
                headers: auth_params
-        
+
         office = @specialist.office
         expect(response).to have_http_status(:ok)
         expect(office.care_recipients.count).to eq(0)
       end
-     end
+    end
   end
+
   context 'ログインしていない' do
     it '利用者を登録できない' do
       post api_specialists_offices_care_recipients_path(@care_recipient.office_id),
-      params: {
-        name: @care_recipient.name,
-        kana: @care_recipient.kana,
-        post_code: @care_recipient.post_code,
-        age: @care_recipient.age,
-        address: @care_recipient.address,
-        family: @care_recipient.family,
-        image: @sample_image,
-        staff_id: @care_recipient.staff_id,
-        office_id: @care_recipient.office_id
-      }
-      
+           params: {
+             name: @care_recipient.name,
+             kana: @care_recipient.kana,
+             post_code: @care_recipient.post_code,
+             age: @care_recipient.age,
+             address: @care_recipient.address,
+             family: @care_recipient.family,
+             image: @sample_image,
+             staff_id: @care_recipient.staff_id,
+             office_id: @care_recipient.office_id
+           }
+
       office = @specialist.office
       expect(office.care_recipients.count).to eq(0)
       expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
## やったこと

- 利用者のCRUDテスト


### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/care_recipients-request-spec
```



### 動作確認 Loom 手順

- テストを実行する

```ruby
docker-compose exec web bundle exec rspec ./spec/requests/api/specialist/care_recipients_spec.rb --format documentation

```
実行結果
```ruby
Api::Specialists::CareRecipients
  ログイン済み
    スペシャリスト
      利用者を登録できる
      利用者の一覧を取得できる
      利用者の詳細データを取得できる
      利用者を編集できる
      利用者を削除できる
  ログインしていない
    利用者を登録できない

Finished in 1.06 seconds (files took 2.63 seconds to load)
6 examples, 0 failures
```

## 参考になったもの

- スタッフのRspec（取得時のデータ型が同じだった為）

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

