### PR TITLE
利用者のモデルテスト

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
 PLATFORMS
   aarch64-linux
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,6 @@ GEM
 PLATFORMS
   aarch64-linux
   x86_64-darwin-19
-  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/care_recipient.rb
+++ b/app/models/care_recipient.rb
@@ -1,9 +1,13 @@
 class CareRecipient < ApplicationRecord
   with_options presence: true do
-    validates :kana
+    validates :kana,  presence: true,
+                      format: { with: /\A[ぁ-んー－　 ]+\z/.freeze },
+                      length: { maximum: 30 }
     validates :name, length: { maximum: 30 }
     validates :family, length: { maximum: 30 }
     validates :address
+    validates :age
+    validates :post_code, format: { with: /\A\d{3}-\d{4}\z/ }
   end
 
   belongs_to :office

--- a/spec/factories/care_recipients.rb
+++ b/spec/factories/care_recipients.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :care_recipient do
     name { '田中 太郎' }
-    kana { 'たなか たろう' }    
+    kana { 'たなか たろう' }
     age { 100 }
-    post_code { Faker::Address.postcode } 
+    post_code { Faker::Address.postcode }
     address   { 'sample address' }
-    family   { 'sample family' }
+    family { 'sample family' }
     association :office
     association :staff
   end

--- a/spec/models/care_recipient_spec.rb
+++ b/spec/models/care_recipient_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe CareRecipient, type: :model do
+  describe 'アソシエーションのテスト' do
+    context 'Officeモデルとの関係' do
+      it 'N:1となっている' do
+        expect(CareRecipient.reflect_on_association(:office).macro).to eq :belongs_to
+      end
+    end
+
+    context 'Staffモデルとの関係' do
+      it 'N:1となっている' do
+        expect(CareRecipient.reflect_on_association(:staff).macro).to eq :belongs_to
+      end
+    end
+  end
+
+  describe 'バリデーションのテスト' do
+    it '事業所id、名前、ふりがな、紹介文がある場合、有効である' do
+      care_recipient = build(:care_recipient)
+      expect(care_recipient).to be_valid
+    end
+
+    it '事業所idがない場合、無効である' do
+      care_recipient = build(:care_recipient, office_id: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:office]).to include('を入力してください')
+    end
+
+    it '名前がない場合、無効である' do
+      care_recipient = build(:care_recipient, name: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:name]).to include('を入力してください')
+    end
+
+    it '名前が31文字以上の場合、無効である' do
+      invalid_name = 'a' * 31
+      care_recipient = build(:care_recipient, name: invalid_name)
+      care_recipient.valid?
+      expect(care_recipient.errors[:name]).to include('は30文字以内で入力してください')
+    end
+
+    it 'ふりがながない場合、無効である' do
+      care_recipient = build(:care_recipient, kana: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:kana]).to include('を入力してください')
+    end
+
+    it 'ふりがながひらがな以外の場合、無効である' do
+      invalid_kana = ['abc', 123, '$%&@!']
+      care_recipient = build(:care_recipient, kana: invalid_kana.first)
+      care_recipient.valid?
+      expect(care_recipient.errors[:kana]).to include('は不正な値です')
+      care_recipient = build(:care_recipient, kana: invalid_kana.second)
+      care_recipient.valid?
+      expect(care_recipient.errors[:kana]).to include('は不正な値です')
+      care_recipient = build(:care_recipient, kana: invalid_kana.third)
+      care_recipient.valid?
+      expect(care_recipient.errors[:kana]).to include('は不正な値です')
+    end
+
+    it 'ふりがなが31文字以上の場合、無効である' do
+      invalid_kana = 'あ' * 31
+      care_recipient = build(:care_recipient, kana: invalid_kana)
+      care_recipient.valid?
+      expect(care_recipient.errors[:kana]).to include('は30文字以内で入力してください')
+    end
+
+    it '年齢がない場合は無効である' do
+      care_recipient = build(:care_recipient, age: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:age]).to include('を入力してください')
+    end
+
+    it '郵便番号がない場合は無効である' do
+      care_recipient = build(:care_recipient, post_code: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:post_code]).to include('を入力してください')
+    end
+
+    it '郵便番号のフォーマットが適切でない場合、無効である' do
+      invalid_post_codes = %w[1234567 12-3456 123-456]
+      invalid_post_codes.each do |invalid_post_code|
+        care_recipient = build(:user, post_code: invalid_post_code)
+        care_recipient.valid?
+        expect(care_recipient.errors[:post_code]).to include('は不正な値です')
+      end
+    end
+
+    it '住所がない場合は無効である' do
+      care_recipient = build(:care_recipient, address: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:address]).to include('を入力してください')
+    end
+
+    it '家族情報が31文字以上の場合、無効である' do
+      invalid_family = 'a' * 31
+      care_recipient = build(:care_recipient, family: invalid_family)
+      care_recipient.valid?
+      expect(care_recipient.errors[:family]).to include('は30文字以内で入力してください')
+    end
+
+    it 'スタッフidがない場合、無効である' do
+      care_recipient = build(:care_recipient, staff_id: nil)
+      care_recipient.valid?
+      expect(care_recipient.errors[:staff]).to include('を入力してください')
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- 利用者モデルテスト作成
- 利用者テーブルの各カラムに足りないバリデーション追加
  -  フォーマットチェック、文字数制限


### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/care-recipient-model-test
```

### 動作確認 Loom 手順

- テスト実行

```ruby
docker-compose exec web bundle exec rspec ./spec/models/care_recipient_spec.rb --format documentation 
```
実行結果
```ruby
CareRecipient
  アソシエーションのテスト
    Officeモデルとの関係
      N:1となっている
    Staffモデルとの関係
      N:1となっている
  バリデーションのテスト
    事業所id、名前、ふりがな、紹介文がある場合、有効である
    事業所idがない場合、無効である
    名前がない場合、無効である
    名前が31文字以上の場合、無効である
    ふりがながない場合、無効である
    ふりがながひらがな以外の場合、無効である
    ふりがなが31文字以上の場合、無効である
    年齢がない場合は無効である
    郵便番号がない場合は無効である
    郵便番号のフォーマットが適切でない場合、無効である
    住所がない場合は無効である
    家族情報が31文字以上の場合、無効である
    スタッフidがない場合、無効である

Finished in 0.55309 seconds (files took 2.57 seconds to load)
15 examples, 0 failures
```
### 確認書類

[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  

## 参考になったサイト

なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```
