### PR TITLE
問い合わせ　リクエストテスト　メール確認

### DIFF
--- a/spec/requests/api/contacts_spec.rb
+++ b/spec/requests/api/contacts_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe 'Api::Contacts', type: :request do
     end
 
     it 'お問い合わせのメールが届いている' do
-      expect(ActionMailer::Base.deliveries.size).to eq(0)
-
       post '/api/contacts',
            params: {
              name: 'サイト利用者',
@@ -24,7 +22,7 @@ RSpec.describe 'Api::Contacts', type: :request do
              types: 'ユーザー',
              content: 'サイト利用者よりお問い合わせをします。'
            }
-      expect(ActionMailer::Base.deliveries.size).to eq(+1)
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
       expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/サイト利用者 様 から問い合わせがありました。/)
       expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/contact@example.com/)
       expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/ユーザー/)

--- a/spec/requests/api/contacts_spec.rb
+++ b/spec/requests/api/contacts_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe 'Api::Contacts', type: :request do
            }
       expect(Contact.count).to eq(1)
       expect(response).to have_http_status(:ok)
-
-      end
+    end
 
     it 'お問い合わせのメールが届いている' do
       expect(ActionMailer::Base.deliveries.size).to eq(0)
@@ -31,7 +30,7 @@ RSpec.describe 'Api::Contacts', type: :request do
       expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/ユーザー/)
       expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/サイト利用者よりお問い合わせをします。/)
     end
-   end
+  end
 
   context '空の情報' do
     it 'お問い合わせを登録できない' do

--- a/spec/requests/api/contacts_spec.rb
+++ b/spec/requests/api/contacts_spec.rb
@@ -12,8 +12,26 @@ RSpec.describe 'Api::Contacts', type: :request do
            }
       expect(Contact.count).to eq(1)
       expect(response).to have_http_status(:ok)
+
+      end
+
+    it 'お問い合わせのメールが届いている' do
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+
+      post '/api/contacts',
+           params: {
+             name: 'サイト利用者',
+             email: 'contact@example.com',
+             types: 'ユーザー',
+             content: 'サイト利用者よりお問い合わせをします。'
+           }
+      expect(ActionMailer::Base.deliveries.size).to eq(+1)
+      expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/サイト利用者 様 から問い合わせがありました。/)
+      expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/contact@example.com/)
+      expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/ユーザー/)
+      expect(ActionMailer::Base.deliveries.first.body.parts[1].body.raw_source).to match(/サイト利用者よりお問い合わせをします。/)
     end
-  end
+   end
 
   context '空の情報' do
     it 'お問い合わせを登録できない' do


### PR DESCRIPTION
## やったこと

- 問い合わせのリクエストテスト 1項目追加
　メールが届いているか確認

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/test/contacts-mail-spec
```

### 動作確認 Loom 手順

- 該当ファイルのRspecテストを実施する


```ruby
docker-compose exec web bundle exec rspec spec/requests/api/contacts_spec.rb --format documentation
```
実行結果
```ruby

Api::Contacts
  有効な情報
    お問い合わせを登録できる
    お問い合わせのメールが届いている
  空の情報
    お問い合わせを登録できない

Finished in 1.09 seconds (files took 4.16 seconds to load)
3 examples, 0 failures
```
[ActionMailer::Base.deliveries の実メール情報](https://gyazo.com/8bfb8e8bafa99b089fac70636bb6fd93)

### 確認書類
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト
- [ActionMailerのRSpecテスト](https://qiita.com/koda_7932/items/c6bba232cbc2073f83fd)
- [Railsでメール周りのrspecを書く際にハマった点](https://qiita.com/F_H_23/items/c30390f54ea234f48cbb)
## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```
