### PR TITLE
paramsの箇所リファクタリング

### DIFF
--- a/spec/requests/api/specialist/offices_spec.rb
+++ b/spec/requests/api/specialist/offices_spec.rb
@@ -90,33 +90,7 @@ RSpec.describe 'Api::Specialists::Offices', type: :request do
       context 'fax_number' do
         context '値が空' do
           it '値がnilとして保存される' do
-            post api_specialists_offices_path,
-                 params: {
-                   office: {
-                     name: @specialist.name,
-                     titie: @office.title,
-                     flags: @office.flags,
-                     business_day_detail: @office.business_day_detail,
-                     officeImages: @sampleImage,
-                     address: @office.address,
-                     post_code: @office.post_code,
-                     fax_number: '',
-                     user_id: @specialist.id
-                   }.to_json,
-                   detail: {
-                     detail: '特徴詳細',
-                     service_type: '介護付きホーム',
-                     open_date: '',
-                     rooms: '',
-                     requirement: '',
-                     facility: '',
-                     management: '',
-                     link: '',
-                     comment_1: '',
-                     comment_2: ''
-                   }.to_json
-                 },
-                 headers: auth_params
+            post api_specialists_offices_path, params: office_params({ fax_number: '' }), headers: auth_params
             expect(Office.count).to eq(1)
             expect(Office.last.fax_number).to be_nil
           end
@@ -125,66 +99,14 @@ RSpec.describe 'Api::Specialists::Offices', type: :request do
         context '登録済みの値' do
           it '登録できない' do
             create(:office, fax_number: '080-0707-0606')
-            post api_specialists_offices_path,
-                 params: {
-                   office: {
-                     name: @specialist.name,
-                     titie: @office.title,
-                     flags: @office.flags,
-                     business_day_detail: @office.business_day_detail,
-                     officeImages: @sampleImage,
-                     address: @office.address,
-                     post_code: @office.post_code,
-                     fax_number: '080-0707-0606',
-                     user_id: @specialist.id
-                   }.to_json,
-                   detail: {
-                     detail: '特徴詳細',
-                     service_type: '介護付きホーム',
-                     open_date: '',
-                     rooms: '',
-                     requirement: '',
-                     facility: '',
-                     management: '',
-                     link: '',
-                     comment_1: '',
-                     comment_2: ''
-                   }.to_json
-                 },
-                 headers: auth_params
+            post api_specialists_offices_path, params: office_params({ fax_number: '080-0707-0606' }), headers: auth_params
             expect(Office.count).to eq(1)
             expect(response).to have_http_status(:unauthorized)
           end
 
           it '登録できる' do
             create(:office, fax_number: '')
-            post api_specialists_offices_path,
-                 params: {
-                   office: {
-                     name: @specialist.name,
-                     titie: @office.title,
-                     flags: @office.flags,
-                     business_day_detail: @office.business_day_detail,
-                     officeImages: @sampleImage,
-                     address: @office.address,
-                     post_code: @office.post_code,
-                     fax_number: '',
-                     user_id: @specialist.id
-                   }.to_json,
-                   detail: {
-                     detail: '特徴詳細',
-                     service_type: '介護付きホーム',
-                     open_date: '',
-                     rooms: '',
-                     requirement: '',
-                     facility: '',
-                     management: '',
-                     link: '',
-                     comment_1: '',
-                     comment_2: ''
-                   }.to_json
-                 },
-                 headers: auth_params
+            post api_specialists_offices_path, params: office_params({ fax_number: '' }), headers: auth_params
             expect(Office.count).to eq(2)
             expect(response).to have_http_status(:ok)
           end

--- a/spec/support/office_params_helper.rb
+++ b/spec/support/office_params_helper.rb
@@ -1,0 +1,91 @@
+module OfficeParamsSupport
+  OFFICE_ATTRIBUTES = {
+    name: 'ケアサービス佐渡',
+    title: '日々の暮らしをサポートします',
+    flags: 8, # 土日休み app/models/office.rb 64-70行目参照
+    business_day_detail: '第３水曜日は休みです',
+    address: '新潟県佐渡市秋津415-9',
+    post_code: '952-0021',
+    fax_number: '026-8773-8873'
+  }.freeze
+
+  DETAIL_ATTRIBUTES = {
+    detail: 'ケアサービス佐渡が最高の介護施設である3つの理由',
+    service_type: '介護付きホーム(サービス付き高齢者向け住宅 特定施設)',
+    open_date: '2011年3月1日',
+    rooms: 30,
+    requirement: '満60歳以上の方、入居時自立・要支援・要介護',
+    facility: 'エントランス、食堂兼機能訓練室、個浴、大浴場、特殊浴槽、和室、談話室、シアタールーム、屋上庭園',
+    management: '株式会社ユニマット リタイアメント・コミュニティ',
+    link: 'https://prum.jp/',
+    comment_1: '大浴場の画像です',
+    comment_2: 'ゴルフ大会の様子です'
+  }.freeze
+
+  # office_params(offices = {}, detail = {})
+  #
+  # 属性を指定しない場合
+  # => office_params()
+  #
+  # officeの属性の指定の仕方
+  # => office_params({name: '株式会社prum', title: '日本一エンジニアが成長できる環境を目指す', ...})
+  #
+  # detailの属性の指定の仕方
+  # => office_params({...}, {detail: '事業形態: SES・受託開発', rooms: 54, ...})
+  #
+  def office_params(offices = {}, details = {})
+    office_attributes, detail_attributes = set_attributes(offices, details)
+    build_params(office_attributes, detail_attributes)
+  end
+
+  private
+
+    def set_attributes(offices, details)
+      office_attributes = set_obj_attributes(obj: offices, constant: OFFICE_ATTRIBUTES)
+      detail_attributes = set_obj_attributes(obj: details, constant: DETAIL_ATTRIBUTES)
+      [office_attributes, detail_attributes]
+    end
+
+    def build_params(office_attributes, detail_attributes)
+      params = {}
+      office = { office: office_attributes.to_json }
+      detail = { detail: detail_attributes.to_json }
+      params.merge(office, detail)
+    end
+
+  # office・detailのparamsをセットする
+  #
+  #
+  # 戻り値 hash
+  # {
+  #   name: 'ケアサービス佐渡',
+  #   title: 'ケアサービス佐渡が最高の介護施設である3つの理由',
+  #   flags: 8,
+  #   .
+  #   .
+  #   .
+  # }
+    def set_obj_attributes(obj:, constant:)
+      attributes = {}
+      constant.each { |key, value|
+        item = obj[key].nil? ? value : obj[key]
+        attributes[key] = item
+      }
+      attributes
+    end
+end
+
+RSpec.configure do |config|
+  # 下記をスペックの中で呼び出す
+  # office_params(offices = {}, details = {})
+  #
+  # 使用例 引数指定しない
+  # post api_specialists_offices_path, params: office_params(), headers: auth_params
+  #
+  # 引数指定 officeの属性を指定
+  # post api_specialists_offices_path, params: office_params({name: 'ケアマーク新潟'}), headers: auth_params
+  #
+  # 引数指定 office, detail両方指定
+  # post api_specialists_offices_path, params: office_params({name: 'ケアパークPRUM'}, {detail: '佐渡島という集中できる環境整備'}), headers: auth_params
+  config.include OfficeParamsSupport
+end


### PR DESCRIPTION
## やったこと

1. office_specのparamsリファクタリング paramsの箇所がメソッドに置き換わる
- before
```ruby
        post api_specialists_offices_path,
             params: {
               office: {
                 name: @specialist.name,
                 titie: @office.title,
                 flags: @office.flags,
                 business_day_detail: @office.business_day_detail,
                 address: @office.address,
                 post_code: @office.post_code,
                 fax_number: @office.fax_number,
                 user_id: @specialist.id
               }.to_json,
               detail: {
                 detail: '特徴詳細',
                 service_type: '介護付きホーム',
                 open_date: '',
                 rooms: '',
                 requirement: '',
                 facility: '',
                 management: '',
                 link: '',
                 comment_1: '',
                 comment_2: ''
               }.to_json,
               officeImages: [@sampleImage]
             },
             headers: auth_params
```
- after
```ruby
  post api_specialists_offices_path, params: office_params(), headers: auth_params
```

### 使い方
- `spec/support/office_params_helper.rb`の79行目参照
```ruby
  # 下記をスペックの中で呼び出す
  # office_params(offices = {}, details = {})
  #
  # 使用例 引数指定しない
  # post api_specialists_offices_path, params: office_params(), headers: auth_params
  #
  # 引数指定 officeの属性を指定
  # post api_specialists_offices_path, params: office_params({name: 'ケアマーク新潟'}), headers: auth_params
  #
  # 引数指定 office, detail両方指定
  # post api_specialists_offices_path, params: office_params({name: 'ケアパークPRUM'}, {detail: '佐渡島という集中できる環境整備'}), headers: auth_params
  #
  # 引数指定 インスタンス
  # post api_specialists_offices_path, params: office_params(@office, @detail), headers: auth_params
  #
  # officeImageを指定する場合は、第３引数でarryで指定する
  # 画像つけたくない場合nilを指定する
  # post api_specialists_offices_path, params: office_params(@office, @detail, [image1, image2, image3]), headers: auth_params
  # post api_specialists_offices_path, params: office_params(@office, @detail, nil), headers: auth_params
  #
  # detailImageを指定する場合は、第４引数でarryで指定する
  # 画像つけたくない場合nilを指定する
  # post api_specialists_offices_path, params: office_params(@office, @detail, nil [image1, image2, image3]), headers: auth_params
  # post api_specialists_offices_path, params: office_params(@office, @detail, nil, nil), headers: auth_params
```

## やらないこと

- 置き換え作業 自分の担当したもののみ(fax番号)

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/feature/build-office-params-helper
```

### 動作確認 Loom 手順

- テストすべてパススことを確認する
```ruby
docker-compose exec web rspec
```

### 確認書類

**URL は該当のものに変えること**  
[API 一覧](https://docs.google.com/spreadsheets/d/1sJ_ZjXjCdBJkpl0gbS_HX3wDeZhihUoqddtIrHCPFnY/edit#gid=0)  
[ユーザーストーリー](https://docs.google.com/spreadsheets/d/1lORIuXfr7PV5dslAHE4NnRGgNqk0hJ5krfN-tV2YKq8/edit#gid=0)  
[テスト仕様書](https://docs.google.com/spreadsheets/d/12xMuHo1K8Fd7FIB7rqeioxdWmrWw7aYK4QZ_Clsfk5Q/edit#gid=1789577746)  
[テーブル定義書](https://docs.google.com/spreadsheets/d/15AbCnOzcFlnN8CO-sXxKM6bMS7VtExbew-FpYHav91Q/edit#gid=1771130073)

## 参考になったサイト

- [サイトのタイトル（必須） なければ「なし」と記入](url)

## 確認項目

- [ ] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [ ] プルリクのタイトルがコミット名そのままになっていないか
- [ ] レビュワーを正しく設定しているか
- [ ] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [ ] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [ ] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

