### PR TITLE
新規登録のメールなど、リダイレクト処理がしないバグ改修

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+/.env
+
 # Ignore bundler config.
 /.bundle
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,16 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  rescue_from ActionController::Redirecting::UnsafeRedirectError, with: :redirect_judgment
+
+  private
+
+    # メールリンクのリダイレクトURLのドメインが、許可されていないドメインだったら例外をコールする
+    # 許可されているドメインの指定は環境変数: MY_APP_FRONT_DOMAINで指定する
+    def redirect_judgment
+      redirect_url  = @_request.query_parameters[:redirect_url]
+      uri = URI.parse(redirect_url)
+      return redirect_to(redirect_url, allow_other_host: true) if uri.host.eql?(ENV['MY_APP_FRONT_DOMAIN'])
+
+      raise ActionController::Redirecting::UnsafeRedirectError, 'リダイレクトしようとしている、ドメインは許可されていません'
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::API
     # メールリンクのリダイレクトURLのドメインが、許可されていないドメインだったら例外をコールする
     # 許可されているドメインの指定は環境変数: MY_APP_FRONT_DOMAINで指定する
     def redirect_judgment
-      redirect_url  = @_request.query_parameters[:redirect_url]
+      redirect_url = @_request.query_parameters[:redirect_url]
       uri = URI.parse(redirect_url)
       return redirect_to(redirect_url, allow_other_host: true) if uri.host.eql?(ENV['MY_APP_FRONT_DOMAIN'])
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - db
     environment:
       - EDITOR=vim
+    env_file:
+      - .env
   wait:
     image: willwill/wait-for-it:latest
   smtp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,7 @@ services:
       - db
     environment:
       - EDITOR=vim
-    env_file:
-      - .env
+      - MY_APP_FRONT_DOMAIN=home-care-navi-v2.herokuapp.com
   wait:
     image: willwill/wait-for-it:latest
   smtp:


### PR DESCRIPTION
## やったこと

- メールのリンククリック時リダイレクトしないバグを改修
- herokuに環境変数セット

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/mail-redirect-bug
```

### 動作確認 Loom 手順

#### ローカルでエラー再現
1.  `app/controllers/application_controller.rb`内の下記の①をコメントアウト
```ruby
class ApplicationController < ActionController::API
  include DeviseTokenAuth::Concerns::SetUserByToken
  # rescue_from ActionController::Redirecting::UnsafeRedirectError, with: :redirect_judgment  # ①この行をコメントアウト

  # 略

end

```
2. フロントの新規登録用の環境変数である`FRONT_TOP_URL`を下記のように書き換える
```js
// .env ファイル内

// before
FRONT_TOP_URL='http://localhost:8000'

// after
FRONT_TOP_URL='https://home-care-navi-v2.herokuapp.com'
```
3. nuxt側のサーバーを立ち上げ直す(環境変数を再読込させるため)
4. 新規登録処理をし、メールのリンクを踏むと下記のエラーが発生することを確認する(本番環境でも同じエラーが出ている、本番環境では画面上になにも表示されないが同じことが起きている)
[![Image from Gyazo](https://i.gyazo.com/8f7aae8484889a3d3099a73cb5461ffd.png)](https://gyazo.com/8f7aae8484889a3d3099a73cb5461ffd)
5. 原因
メールのリンクは内部のロジックで下記のメソッドを使用している 
```ruby
redirect_to()
```
 - [devise_token_auth redirect_toが使用されている場所](https://github.com/lynndylanhurley/devise_token_auth/search?q=redirect_to)
rails 7から外部のドメインにリダイレクトしようとすると`ActionController::Redirecting::UnsafeRedirectError`がコールされるようになった。  
開発環境でこのエラーが出なかったのはドメイン名が同じだったためエラーが起きなかった。  
```ruby
# 開発環境  ドメイン名が同じ`localhost`なのでredirectしてもエラーが起きなかった。
http://localhost:8000  # front
ドメイン名: localhost

http://localhost:3000  # api
ドメイン名: localhost

# 本番環境 ドメイン名が異なるのでredirectするとエラーが出た
https://home-care-navi-api-v2.herokuapp.com  #api
ドメイン名: home-care-navi-api-v2

https://home-care-navi-v2.herokuapp.com  #front
ドメイン名: home-care-navi-v2
```

#### 外部のドメイン名でもリダイレクトできることを確認する
1. `API`側に環境変数を確認する
```ruby
# docker 立ち上げ直し(.envファイルの内容を反映させるため) restartだと反映されないので下記の通り行う
docker-compose down

docker-compose build

docker-compose up -d

docker-compose exec web bash

# コンテナ内で設定した環境変数が存在しているか確認する `env`と実行したら①が表示されているか確認する
$ env
.
.

MY_APP_FRONT_DOMAIN=home-care-navi-v2.herokuapp.com # ①これが表示されていればok
.
.
,
```
2. `app/controllers/application_controller.rb`のコメントアウト下箇所を解除
3. 新規登録処理をして、メールのリンクを踏むと次は本番のエラーが出ずに外部のドメイン名でもリダイレクト(home-care-navi-v2.herokuapp.com)できたことを確認する
4. フロント側の`.env`ファイルの`FRONT_TOP_URL`の値をもとに戻しておく

#### heroku側に環境変数がセットされているか確認する
1. ターミナルで下記のコマンド実行
```ruby
heroku run bash
```
2. bash内で`env`を実行し`MY_APP_FRONT_DOMAIN`が存在しまた値が`home-care-navi-v2.herokuapp.com`になっていることを確認する  ※真ん中ぐらいにある
```ruby
env
.
.
MY_APP_FRONT_DOMAIN=home-care-navi-v2.herokuapp.com
.
.
```

## その他
わからないことがありましたら、コメントに残してください。プルリク説明会の時に回答します。

今までなんで動いていたのか？
- 外部のredirectをすべて許可する設定をtrueにしていた。これはセキュリテー的に良くないので今回の実装は許可性にした
- なにかのタイミングで消してしまったと思われる rubocopの自動修正時とか 自動でやって意識できないで消し待ったとかが一番可能性高い

## 参考になったサイト

- [ActionController::Redirecting::UnsafeRedirectError概要](https://blog.saeloun.com/2022/02/08/rails-7-raise-unsafe-redirect-error.html)
- [rails 7 アプリケーション設定](https://qiita.com/htz/items/5e70dcbb589ec6b37448#configaction_controllerraise_on_open_redirects)

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

