### PR TITLE
パスワードリセットのリダイレクト時はquery含めるように修正

### DIFF
--- a/app/controllers/api/overrides/reset_passwords_controller.rb
+++ b/app/controllers/api/overrides/reset_passwords_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  module Overrides
+    class ResetPasswordsController < DeviseTokenAuth::PasswordsController
+      # this is where users arrive after visiting the password reset confirmation link
+      def edit
+        # if a user is not found, return nil
+        @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
+
+        if @resource&.reset_password_period_valid?
+          token = @resource.create_token unless require_client_password_reset_token?
+
+          # ensure that user is confirmed
+          @resource.skip_confirmation! if confirmable_enabled? && !@resource.confirmed_at
+          # allow user to change password once without current_password
+          @resource.allow_password_change = true if recoverable_enabled?
+
+          @resource.save!
+
+          yield @resource if block_given?
+
+          if require_client_password_reset_token?
+            redirect_to DeviseTokenAuth::Url.generate(@redirect_url, reset_password_token: resource_params[:reset_password_token])
+          else
+
+            if DeviseTokenAuth.cookie_enabled
+              set_token_in_cookie(@resource, token)
+            end
+
+            redirect_header_options = { reset_password: true }
+            redirect_headers = build_redirect_headers(token.token,
+                                                      token.client,
+                                                      redirect_header_options)
+            redirect_to(@resource.build_auth_url(@redirect_url,
+                                                 redirect_headers), allow_other_host: domain_allowed?)
+          end
+        else
+          render_edit_error
+        end
+      end
+
+      protected
+
+        def render_update_error_unauthorized
+          render_error(401, '不正な認証情報が不正です。最初からやり直してください')
+        end
+
+        def domain_allowed?
+          uri = URI.parse(@redirect_url)
+          uri.host.eql?(ENV['MY_APP_FRONT_DOMAIN'])
+        end
+    end
+  end
+end

--- a/app/controllers/api/overrides/reset_passwords_controller.rb
+++ b/app/controllers/api/overrides/reset_passwords_controller.rb
@@ -41,7 +41,7 @@ module Api
       protected
 
         def render_update_error_unauthorized
-          render_error(401, '不正な認証情報が不正です。最初からやり直してください')
+          render_error(401, '認証情報が不正です。最初からやり直してください')
         end
 
         def domain_allowed?

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p><%= t(:hello).capitalize %> <%= @resource.email %>!</p>
+
+<p><%= t '.request_reset_link_msg' %></p>
+
+<p><%= link_to t('.password_change_link'), api_reset_password_edit_url(@resource, reset_password_token: @token, config: message['client-config'].to_s, redirect_url: message['redirect-url'].to_s).html_safe %></p>
+
+<p><%= t '.ignore_mail_msg' %></p>
+<p><%= t '.no_changes_msg' %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
-
-  mount_devise_token_auth_for "Specialist", at: 'api/specialists/users', skip: [:omniauth_callbacks, :sessions, :token_validations], controllers: {
+  mount_devise_token_auth_for 'Specialist', at: 'api/specialists/users', skip: %i[omniauth_callbacks sessions token_validations password], controllers: {
     registrations: 'api/overrides/specialist/specialist_registrations'
   }
-  mount_devise_token_auth_for "Customer", at: 'api/customer', skip: [:omniauth_callbacks, :sessions, :token_validations], controllers: {
+  mount_devise_token_auth_for 'Customer', at: 'api/customer', skip: %i[omniauth_callbacks sessions token_validations password], controllers: {
     registrations: 'api/overrides/customer/registrations'
   }
-  mount_devise_token_auth_for "User", at: 'api/users',  skip: [:registrations, :omniauth_callbacks, :sessions, :token_validations, :password, :confirmations]
+
+  mount_devise_token_auth_for 'User', at: 'api/users',
+                                      skip: %i[registrations omniauth_callbacks sessions token_validations confirmations password]
 
   devise_for :users, controllers: { confirmations: 'confirmations' }
 
@@ -16,6 +17,9 @@ Rails.application.routes.draw do
     post    'api/users',  to: 'api/overrides/customer/registrations#password_check'
     get     'api/users',  to: 'api/overrides/customer/registrations#show'
     delete  'api/users',  to: 'api/overrides/customer/registrations#destroy'
+    post    'api/reset-password', to: 'api/overrides/reset_passwords#create'
+    put     'api/reset-password', to: 'api/overrides/reset_passwords#update'
+    get     'api/reset-password/edit', to: 'api/overrides/reset_passwords#edit'
   end
 
   namespace :api do
@@ -25,23 +29,23 @@ Rails.application.routes.draw do
     get '/histories',          to: 'customer/histories#index'
     get '/check-phone-number', to: 'check#check_phone_number'
     scope module: :customer do
-      resources :offices, only: [:index, :show] do
+      resources :offices, only: %i[index show] do
         resources :thanks, only: [:create], controller: 'thanks'
         resources :appointments, only: [:create]
-        resources :bookmarks, only: [:create, :destroy]
-        resources :histories, only: [:create, :update]
+        resources :bookmarks, only: %i[create destroy]
+        resources :histories, only: %i[create update]
       end
-      resources :thanks, only: [:index, :show, :update, :destroy]
+      resources :thanks, only: %i[index show update destroy]
     end
   end
 
   namespace :api do
     resource :specialists do
-      resource :offices ,controller: 'specialists/offices' do
-        resources :staffs, controller: 'specialists/staffs', only: [:index, :show, :create, :update, :destroy]
-        resources :care_recipients, controller: 'specialists/care_recipients', only: [:index, :create, :show, :update, :destroy]
-        resources :appointments, controller: 'specialists/appointments', only: [:index, :update, :destroy]
-        resources :thanks, controller: 'specialists/thanks', only: [:index, :destroy]
+      resource :offices, controller: 'specialists/offices' do
+        resources :staffs, controller: 'specialists/staffs', only: %i[index show create update destroy]
+        resources :care_recipients, controller: 'specialists/care_recipients', only: %i[index create show update destroy]
+        resources :appointments, controller: 'specialists/appointments', only: %i[index update destroy]
+        resources :thanks, controller: 'specialists/thanks', only: %i[index destroy]
       end
     end
   end

--- a/spec/requests/api/overrides/customer/reset_passwords_spec.rb
+++ b/spec/requests/api/overrides/customer/reset_passwords_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Overrides::Customer::ResetPasswords", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/overrides/customer/reset_passwords_spec.rb
+++ b/spec/requests/api/overrides/customer/reset_passwords_spec.rb
@@ -2,6 +2,5 @@ require 'rails_helper'
 
 RSpec.describe "Api::Overrides::Customer::ResetPasswords", type: :request do
   describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
## やったこと

- パスワードリセットエンドポイントの共通化(customer/specialist)
- パスワードリセット機能 eidtアクション redirect時にquery含めるように修正

## やらないこと

- rubocop一部修正: ` app/controllers/api/overrides/reset_passwords_controller.rb`
- rspec このプルリクでは書かない

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/technical/password-reset-query-set
```

### Front 側

- fetch and checkoutruby
```ruby
git fetch && git checkout origin/technical/password-reset-404
```

### 動作確認 Loom 手順

- ↓動作確認手順はこちらに記述済み
https://github.com/koki-takishita/home-care-navi-front/pull/320

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか

```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [ ] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

