### PR TITLE
閲覧履歴コントローラーのリファクタリング

### DIFF
--- a/app/controllers/api/customer/histories_controller.rb
+++ b/app/controllers/api/customer/histories_controller.rb
@@ -1,4 +1,4 @@
-class Api::Customer::HistoriesController < Api::Customer::OfficesController
+class Api::Customer::HistoriesController < ApplicationController
   before_action :authenticate_customer!, only: %i[index create update]
   before_action :set_customer, only: %i[index create update]
   before_action :set_history, only: [:update]
@@ -30,11 +30,10 @@ class Api::Customer::HistoriesController < Api::Customer::OfficesController
   end
 
   def update
-    if @history.valid?
-      # rubocop:disable Rails::SkipsModelValidations
-      # updated_atのみ更新
-      @history.touch
-      # rubocop:enable Rails::SkipsModelValidations
+    # updated_atのみ更新
+    # rubocop:disable Rails::SkipsModelValidations
+    if @history.touch
+    # rubocop:enable Rails::SkipsModelValidations
       render json: {
         message: '閲覧データを更新しました'
       }, status: :ok
@@ -68,11 +67,11 @@ class Api::Customer::HistoriesController < Api::Customer::OfficesController
 
   def build_json(offices)
     offices.each_with_index.map do |office|
-      thank = build_json_from_thank_table_attributes(office)
-      detail      = build_json_from_detail_table_attributes(office)
-      staff_count = build_json_from_staff_table_count_json(office)
-      bookmark    = build_json_from_bookmark_table(office)
-      image       = build_json_image(office)
+      thank = { thank: { comments: office.latest_thank_comment } }
+      detail      = { detail: office.detail }
+      staff_count = { staffCount: office.staff_count }
+      bookmark    = { bookmark: Bookmark.search_office_bookmark(office.id, current_customer.id).first }
+      image       = { image: office.first_image_url }
       office      = office.attributes
 
       office.merge(thank, detail, image, staff_count, bookmark)

--- a/app/controllers/api/customer/offices_controller.rb
+++ b/app/controllers/api/customer/offices_controller.rb
@@ -160,8 +160,6 @@ class Api::Customer::OfficesController < ApplicationController
     result
   end
 
-	public
-
   def build_json_image(office)
     image = if(office.images.size > 0)
               image_url = return_random_image_url(office)


### PR DESCRIPTION
## やったこと

- 閲覧履歴コントローラーのリファクタリング
  - データの取得時に、モデル内のメソッドを活用するように変更
  - カスタマー側コントローラーの一部メソッドを`public`にしていたものを`private`に変更

## やらないこと

- なし

### API 側

- fetch and checkout

```ruby
git fetch && git checkout origin/fix/refactoring-histories_controller
```


### 動作確認 Loom 手順

- フロントで閲覧履歴の登録と更新・データの表示が正常に行われているか確認

## 参考になったサイト

- なし

## 確認項目

- [x] ここまでで各項目に漏れなく記入しているか・不要な箇所はないか
```javascript
NG
API・Front両方ブランチを指定していない（developの場合は省略可）
Frontのプルリクとセットで確認する場合は、FrontのプルリクのURLを添付する
```

- [x] プルリクのタイトルがコミット名そのままになっていないか
- [x] レビュワーを正しく設定しているか
- [x] 変数名・メソッド名は適切か　[Ruby の命名規約](https://qiita.com/takahashim/items/ccfd489c9b26f15b7193)
- [x] インデントが揃えてあるか 余分なスペースはないか
- Rubocop 自動修正コマンド

```ruby
docker-compose exec web bundle exec rubocop --auto-correct 作成したファイルの相対パス
```

- [x] 新規で作成したファイルに対して Rubocop のチェックがすべてパスしているか
```ruby
docker-compose exec web bundle exec rubocop 作成・変更したファイルの相対パス
```

